### PR TITLE
Possibilité de définir min/maxzoom sur les datasources projets

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -111,6 +111,8 @@ Plusieurs sources de données sont mobilisables, et sont à faire apparaître da
 * `name` : nom à faire apparaître à l'utilisateur
 * `subtitles` : (optionel) objet clé > valeur pour remplacer les sous-titres des signalements Osmose (recherche par motif)
 * `buttons` : libellé à faire apparaître sur les boutons d'édition (exemple `{ "done": "C'est fait", "false": "Rien ici" }`)
+* `minZoom` : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxZoom` : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 
 #### Notes OSM
 
@@ -129,6 +131,8 @@ Les objets actuellement présents dans OpenStreetMap peuvent être affichés pou
 * `source` : type de source, valeur obligatoire `osm`
 * `name` : nom à faire apparaître à l'utilisateur
 * `description` : texte descriptif de l'objet affiché
+* `minZoom` : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxZoom` : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 
 Cette source ne peut apparaître qu'une seule fois, et correspond aux objets recherchés dans les options `database` de `info.json`.
 
@@ -139,6 +143,8 @@ Des objets indirectement liés au projet mais pertinents pour la contribution pe
 * `source` : type de source, valeur obligatoire `osm-compare`
 * `name` : nom à faire apparaître à l'utilisateur
 * `description` : texte descriptif de l'objet affiché
+* `minZoom` : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxZoom` : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 
 Cette source ne peut apparaître qu'une seule fois, et correspond aux objets recherchés dans les options `database.compare` de `info.json`.
 

--- a/website/templates/components/map.pug
+++ b/website/templates/components/map.pug
@@ -84,7 +84,7 @@ script.
 
 	// Alert for zoom/search
 	const toggleZoomAlert = () => {
-		if(map.getZoom() >= 7) {
+		if(map.getZoom() >= !{minZoom}) {
 			for(let d of document.querySelectorAll(".show-low-zoom")) {
 				d.classList.add("d-none");
 			}

--- a/website/utils.js
+++ b/website/utils.js
@@ -37,6 +37,7 @@ exports.getMapStyle = (p) => {
 	.then(res => res.json())
 	.then(style => {
 		const legend = [];
+		let vectorMinZoom = 50;
 		const sources = {
 			ign: {
 				type: "raster",
@@ -81,11 +82,13 @@ exports.getMapStyle = (p) => {
 				const id = `${ds.source}_${dsid}`;
 				const color = ds.color || "#FF7043"; // Orange
 				const layer = `public.pdm_project_${p.id.split("_").pop()}_compare_tiles_filtered`;
+				let minZoom = ds.hasOwnProperty("minZoom") && ds.minZoom > 0 ? ds.minZoom : 9
+				vectorMinZoom = Math.min(vectorMinZoom, minZoom);
 				sources[id] = {
 					type: "vector",
 					tiles: [ `${CONFIG.PDM_TILES_URL}/${layer}/{z}/{x}/{y}.mvt` ],
-					minzoom: 9,
-					maxzoom: 14
+					minzoom: minZoom,
+					maxzoom: ds.hasOwnProperty("maxZoom") && ds.maxZoom > 0 ? ds.maxZoom : 14
 				};
 
 				layers.push({
@@ -110,11 +113,13 @@ exports.getMapStyle = (p) => {
 				const id = `${ds.source}_${dsid}`;
 				const color = ds.color || "#2E7D32"; // Green
 				const layer = `public.pdm_project_${p.id.split("_").pop()}`;
+				let minZoom = ds.hasOwnProperty("minZoom") && ds.minZoom > 0 ? ds.minZoom : 7
+				vectorMinZoom = Math.min(vectorMinZoom, minZoom);
 				sources[id] = {
 					type: "vector",
 					tiles: [ `${CONFIG.PDM_TILES_URL}/${layer}/{z}/{x}/{y}.mvt` ],
-					minzoom: 7,
-					maxzoom: 14
+					minzoom: minZoom,
+					maxzoom: ds.hasOwnProperty("maxZoom") && ds.maxZoom > 0 ? ds.maxZoom : 14
 				};
 
 				layers.push({
@@ -132,15 +137,17 @@ exports.getMapStyle = (p) => {
 			p.datasources
 			.filter(ds => ds.source === "osmose")
 			.forEach(ds => {
-				const id = `osmose_${ds.item}_${ds.class || "all"}`;
+				const id = `${ds.source}_${ds.item}_${ds.class || "all"}`;
 				const params = { item: ds.item, class: ds.class, country: ds.country };
 				const color = ds.color || "#b71c1c"; // Red
+				let minZoom = ds.hasOwnProperty("minZoom") && ds.minZoom > 0 ? ds.minZoom : 7
+				vectorMinZoom = Math.min(vectorMinZoom, minZoom);
 
 				sources[id] = {
 					type: "vector",
 					tiles: [ `${CONFIG.OSMOSE_URL}/api/0.3/issues/{z}/{x}/{y}.mvt?${exports.queryParams(params)}` ],
-					minzoom: 7,
-					maxzoom: 18
+					minzoom: minZoom,
+					maxzoom: ds.hasOwnProperty("maxZoom") && ds.maxZoom > 0 ? ds.maxZoom : 18
 				};
 
 				layers.push({
@@ -178,6 +185,7 @@ exports.getMapStyle = (p) => {
 
 		return {
 			mapstyle: style,
+			minZoom: vectorMinZoom,
 			legend,
 			pdmSources: Object.keys(sources)
 		};

--- a/website/utils.js
+++ b/website/utils.js
@@ -165,7 +165,7 @@ exports.getMapStyle = (p) => {
 			p.datasources
 			.filter(ds => ds.source === "notes")
 			.forEach((ds, dsid) => {
-				const id = `notes_${dsid}`;
+				const id = `${ds.source}_${dsid}`;
 				const color = ds.color || "#01579B"; // Blue
 				sources[id] = { type: "geojson", data: { type: "FeatureCollection", features: [] } };
 


### PR DESCRIPTION
Le dev en cours pour Enedis met en évidence que le zoom 7 ou 8 des tuiles vectorielles est un peu trop chargé pour les poteaux.  
J'ai donc pensé que ce serait pas mal de pouvoir définir un min/max zoom par datasource pour chaque projet.

Les valeurs par défaut sont conservées, il n'y a pas lieu de modifier les projets existants