### PR TITLE
Ajout des datasources background

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -153,6 +153,20 @@ Des objets indirectement liés au projet mais pertinents pour la contribution pe
 
 Cette source ne peut apparaître qu'une seule fois, et correspond aux objets recherchés dans les options `database.compare` de `info.json`.
 
+#### Fonds raster
+
+Des couches raster peuvent être ajoutées en fond de carte pour faciliter la contribution ou donner plus de contexte; Les propriétés suivantes doivent être définies:
+
+* `source` : type de source, valeur obligatoire `background`
+* `name` : nom à faire apparaître à l'utilisateur
+* `tiles` : Tableau d'URL TMS
+* `attribution` : Attribution à faire apparaitre sur la carte
+* `minZoom` : Niveau de zoom minimum au delà duquel la couche est visible (défaut 2)
+* `maxZoom` : Niveau de zoom maximal au delà duquel la couche n'est plus visible (défaut 19)
+* `tileSize` : Taille d'une arrête de tuile en pixels (défaut 256)
+
+Ces sources doivent être déclarées dans l'ordre inverse d'apparition. La couche inférieure doit être donnée en premier.
+
 
 ### Décomptes et statistiques
 

--- a/projects/2017-04_electionboard/info.json
+++ b/projects/2017-04_electionboard/info.json
@@ -33,6 +33,12 @@
 			"source": "osm-compare",
 			"name": "Lieu pouvant disposer d'un panneau",
 			"description": "Ce lieu est susceptible d'être équipé de panneaux électoraux. Vous pouvez vérifier sur place la localisation précise du panneau et l'ajouter à OSM."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/projects/2018-07_substation/info.json
+++ b/projects/2018-07_substation/info.json
@@ -28,6 +28,12 @@
 			"source": "osm",
 			"name": "Poste dans OSM",
 			"description": "Ce poste électrique existe déjà dans OSM. Vous pouvez compléter ou modifier ses informations si nécessaire."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/projects/2018-11_police/info.json
+++ b/projects/2018-11_police/info.json
@@ -22,6 +22,12 @@
 			"source": "osm",
 			"name": "Gendarmerie dans OSM",
 			"description": "Cette gendarmerie existe déjà dans OSM. Vous pouvez compléter ou modifier ses informations si nécessaire."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/projects/2020-03_evcharging/info.json
+++ b/projects/2020-03_evcharging/info.json
@@ -22,6 +22,12 @@
 			"source": "osm",
 			"name": "Borne dans OSM",
 			"description": "Cette borne existe déjà dans OSM. Vous pouvez compléter ou modifier ses informations si nécessaire."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/projects/2020-04_covid19/info.json
+++ b/projects/2020-04_covid19/info.json
@@ -20,6 +20,12 @@
 			"source": "osm",
 			"name": "Lieu avec horaires de confinement",
 			"description": "Ce lieu a ses horaires durant le confinement renseignées dans OSM."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/projects/2020-09_aed/info.json
+++ b/projects/2020-09_aed/info.json
@@ -52,6 +52,12 @@
 			"source": "osm-compare",
 			"name": "Lieu pouvant disposer d'un DAE",
 			"description": "Ce lieu est susceptible de disposer d'un défibrillateur. Vous pouvez vérifier sur place la localisation de l'appareil et l'ajouter à OSM."
+		},
+		{
+			"source": "background",
+			"tiles": [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
+			"name": "IGN BD Ortho",
+			"attribution": "<a href=\"https://openstreetmap.fr/bdortho\" target=\"_blank\">&copy; BDOrtho IGN</a>"
 		}
 	],
 	"statistics": {

--- a/website/index.js
+++ b/website/index.js
@@ -13,17 +13,14 @@ const CONFIG = require('../config.json');
 const { foldProjects, queryParams, getMapStyle, getBadgesDetails, getOsmToUrlMappings } = require('./utils');
 const { Pool } = require('pg');
 
-
 /*
  * Connect to database
  */
-
 const pool = new Pool({
   host: CONFIG.DB_HOST,
   database: CONFIG.DB_NAME,
   port: CONFIG.DB_PORT,
 });
-
 
 /*
  * Init API

--- a/website/templates/components/map.pug
+++ b/website/templates/components/map.pug
@@ -104,36 +104,6 @@ script.
 	toggleZoomAlert();
 	map.on("zoom", toggleZoomAlert);
 
-	// Button for switching between aerial imagery and map tiles
-	class TilesControl {
-		onAdd(map) {
-			this._map = map;
-			this._container = document.createElement('div');
-			this._container.className = "mapboxgl-ctrl mapboxgl-ctrl-group";
-			const btn = document.createElement("button");
-			btn.type = "button";
-			btn.title = "Afficher / masquer l'imagerie satellite";
-			btn.classList.add("pdm-btn-layers");
-			btn.innerHTML = `<i class="fa fa-layer-group" style="font-size: 18px"></i>`;
-
-			btn.addEventListener("click", e => {
-				if(!btn.classList.contains("pdm-btn-enabled")) {
-					map.setLayoutProperty("bg_aerial", "visibility", "visible");
-					btn.classList.add("pdm-btn-enabled");
-				}
-				else {
-					map.setLayoutProperty("bg_aerial", "visibility", "none");
-					btn.classList.remove("pdm-btn-enabled");
-				}
-			});
-
-			this._container.appendChild(btn);
-			return this._container;
-		}
-	}
-
-	map.addControl(new TilesControl(), "top-right");
-
 	// Display notes layers if any
 	const notesSources = !{JSON.stringify(datasources.filter(ds => ds.source === "notes"))};
 	const geojsonBounds = !{JSON.stringify(CONFIG.GEOJSON_BOUNDS)};

--- a/website/templates/components/map_sidebar_legend.pug
+++ b/website/templates/components/map_sidebar_legend.pug
@@ -14,16 +14,30 @@ div.btn-group.w-100.mb-2.mt-2(role="group")
 //- Legend entries
 div.map-legend.mb-2.pb-2(style="border-bottom: 1px solid #bbb")
 	each lg in legend
-		label.switch(id=`pdm-legend-${lg.layerId}` title="Afficher/masquer la couche")
-			if lg.media=="vector"
+		if lg.media=="vector"
+			label.switch(id=`pdm-legend-${lg.layerId}` title="Afficher/masquer la couche")
 				div.pdm-color-patch(style=`border-color: ${lg.color}`)
-			else
+					
+				div.switch-text= lg.label
+				div.switch-box
+					input(type="checkbox")
+					span.slider.round
+
+//- Editor button
+if editors.pdm
+	div#legend-edit-button.mb-2
+
+//- Background legend
+div.map-background.mt-2.pb-2.pt-2(style="border-top: 1px solid #bbb;")
+	each lg in legend
+		if lg.media!="vector"
+			label.switch(id=`pdm-legend-${lg.layerId}` title="Afficher/masquer la couche")
 				div.pdm-raster-patch
-				
-			div.switch-text= lg.label
-			div.switch-box
-				input(type="checkbox")
-				span.slider.round
+					
+				div.switch-text= lg.label
+				div.switch-box
+					input(type="checkbox")
+					span.slider.round
 
 //- Make legend symbol clickable to enable/disable layer
 -
@@ -45,12 +59,6 @@ div.map-legend.mb-2.pb-2(style="border-bottom: 1px solid #bbb")
 		.join("\n");
 
 script !{legendClickEvents}
-
-
-//- Editor button
-if editors.pdm
-	div#legend-edit-button.mb-2
-
 
 //- KML Export button
 a#pdm-export-kml.btn.btn-block.btn-outline-secondary(role="button" title="Télécharger un fichier KML pour contribuer avec une application de smartphone")

--- a/website/templates/components/map_sidebar_legend.pug
+++ b/website/templates/components/map_sidebar_legend.pug
@@ -15,7 +15,11 @@ div.btn-group.w-100.mb-2.mt-2(role="group")
 div.map-legend.mb-2.pb-2(style="border-bottom: 1px solid #bbb")
 	each lg in legend
 		label.switch(id=`pdm-legend-${lg.layerId}` title="Afficher/masquer la couche")
-			div.pdm-color-patch(style=`border-color: ${lg.color}`)
+			if lg.media=="vector"
+				div.pdm-color-patch(style=`border-color: ${lg.color}`)
+			else
+				div.pdm-raster-patch
+				
 			div.switch-text= lg.label
 			div.switch-box
 				input(type="checkbox")
@@ -24,18 +28,20 @@ div.map-legend.mb-2.pb-2(style="border-bottom: 1px solid #bbb")
 //- Make legend symbol clickable to enable/disable layer
 -
 	const legendClickEvents = legend
-		.map(lg => lg.layerId)
-		.map((id,i) => `
-			const domLegend${i} = document.getElementById('pdm-legend-${id}').querySelector("input");
-			domLegend${i}.checked = true;
-			domLegend${i}.addEventListener("change", e => {
-				if(domLegend${i}.checked) {
-					map.setFilter('${id}', null);
-				}
-				else {
-					map.setFilter('${id}', ['boolean', false]);
-				}
-			});`)
+		.map((lg,i) => {
+			let makeVisible = lg.media == "raster" ? `map.setLayoutProperty("${lg.layerId}", "visibility", "visible");` : `map.setFilter('${lg.layerId}', null);`;
+			let makeInvisible = lg.media == "raster" ? `map.setLayoutProperty("${lg.layerId}", "visibility", "none");` : `map.setFilter('${lg.layerId}', ['boolean', false]);`;
+			return `
+				const domLegend${i} = document.getElementById('pdm-legend-${lg.layerId}').querySelector("input");
+				domLegend${i}.checked = ${lg.media == "raster" ? "false" : "true"};
+				domLegend${i}.addEventListener("change", e => {
+					if(domLegend${i}.checked) {
+						${makeVisible}
+					}else {
+						${makeInvisible}
+					}
+				});`
+		})
 		.join("\n");
 
 script !{legendClickEvents}

--- a/website/templates/style.css
+++ b/website/templates/style.css
@@ -322,10 +322,6 @@ a.navbar-brand:hover {
 	text-decoration: none !important;
 }
 
-.pdm-btn-layers.pdm-btn-enabled {
-	color: #28a745;
-}
-
 .map-legend > div {
 	display: flex;
 	align-items: center;
@@ -336,6 +332,15 @@ a.navbar-brand:hover {
 
 .map-legend .pdm-color-patch {
 	margin-right: 5px;
+}
+.map-legend .pdm-raster-patch {
+	min-height: 30px;
+	min-width: 30px;
+	background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%208%208%22%3E%0A%20%20%3Cpath%20d%3D%22M0%200v4h4v-4h-4zm5%202v3h-3v1h4v-4h-1zm2%202v3h-3v1h4v-4h-1z%22%20/%3E%0A%3C/svg%3E')
+	  white;
+	background-repeat: no-repeat;
+	background-size: 15px 15px;
+	background-position: center;
 }
 
 .text-line-through {
@@ -363,8 +368,6 @@ a.navbar-brand:hover {
 	width: 32px;
 	height: 32px;
 }
-
-
 
 /*
  * Map sidebar

--- a/website/templates/style.css
+++ b/website/templates/style.css
@@ -333,7 +333,23 @@ a.navbar-brand:hover {
 .map-legend .pdm-color-patch {
 	margin-right: 5px;
 }
-.map-legend .pdm-raster-patch {
+
+.map-background {
+	position:absolute;
+	bottom:0;
+	width:272px;
+	background-color:#fff;
+}
+
+.map-background > div {
+	display: flex;
+	align-items: center;
+	line-height: 1.5rem;
+	cursor: pointer;
+	align-items: center;
+}
+
+.map-background .pdm-raster-patch {
 	min-height: 30px;
 	min-width: 30px;
 	background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%228%22%20height%3D%228%22%20viewBox%3D%220%200%208%208%22%3E%0A%20%20%3Cpath%20d%3D%22M0%200v4h4v-4h-4zm5%202v3h-3v1h4v-4h-1zm2%202v3h-3v1h4v-4h-1z%22%20/%3E%0A%3C/svg%3E')

--- a/website/utils.js
+++ b/website/utils.js
@@ -39,19 +39,8 @@ exports.getMapStyle = (p) => {
 	.then(style => {
 		const legend = [];
 		let vectorMinZoom = 50;
-		const sources = {
-			ign: {
-				type: "raster",
-				tiles: [ "https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/{z}/{x}/{y}.jpg" ],
-				maxzoom: 19,
-				minzoom: 2,
-				tileSize: 256,
-				attribution: `<a href="https://openstreetmap.fr/bdortho" target="_blank">&copy; BDOrtho IGN</a>`
-			}
-		};
-		const layers = [
-			{ id: "bg_aerial", source: "ign", type: "raster", layout: { visibility: "none" } }
-		];
+		let sources = {};
+		let layers = [];
 
 		if(p) {
 			const circlePaint = {
@@ -75,6 +64,29 @@ exports.getMapStyle = (p) => {
 					19, 7
 				]
 			};
+
+			// Backgrounds
+			p.datasources
+			.filter(ds => "background" === ds.source)
+			.forEach((ds, dsid) => {
+				const id = `${ds.source}_${dsid}`;
+
+				sources[id] = Object.assign({
+					minZoom: 2,
+					maxZoom: 19,
+					tileSize: 256,
+					type: "raster"
+				}, ds);
+
+				layers.push({
+					id: id,
+					source: id,
+					type: "raster",
+					layout: { visibility: "none" }
+				});
+
+				legend.push({ media: "raster", color:null, label: ds.name, layerId: id });
+			});
 
 			// OSM Compare
 			p.datasources
@@ -104,7 +116,7 @@ exports.getMapStyle = (p) => {
 					}
 				});
 
-				legend.push({ color, label: ds.name, layerId: id });
+				legend.push({ media: "vector", color, label: ds.name, layerId: id });
 			});
 
 			// OSM
@@ -131,7 +143,7 @@ exports.getMapStyle = (p) => {
 					paint: Object.assign({ "circle-stroke-color": color }, circlePaint)
 				});
 
-				legend.push({ color, label: ds.name, layerId: id });
+				legend.push({ media: "vector", color, label: ds.name, layerId: id });
 			});
 
 			// Osmose
@@ -159,7 +171,7 @@ exports.getMapStyle = (p) => {
 					paint: Object.assign({ "circle-stroke-color": color }, circlePaint)
 				});
 
-				legend.push({ color, label: ds.name, layerId: id });
+				legend.push({ media: "vector", color, label: ds.name, layerId: id });
 			});
 
 			// Notes
@@ -177,7 +189,7 @@ exports.getMapStyle = (p) => {
 					paint: Object.assign({ "circle-stroke-color": color }, circlePaint)
 				});
 
-				legend.push({ color, label: ds.name, layerId: id });
+				legend.push({ media: "vector", color, label: ds.name, layerId: id });
 			});
 		}
 
@@ -187,7 +199,7 @@ exports.getMapStyle = (p) => {
 		return {
 			mapstyle: style,
 			minZoom: vectorMinZoom,
-			legend,
+			legend: legend.reverse(),
 			pdmSources: Object.keys(sources)
 		};
 	});


### PR DESCRIPTION
Modification du comportement des couches de fond de carte. Le besoin existait pour Enedis d'ajouter une couche technique par dessus le fond de carte.

Création des datasources "background", ajout de la BD Ortho à tous les projets existant. Ces couches sont visibles en tant que raster dans la légende de l'éditeur. Suppression du controle mapbox permettant de masquer/afficher la BD Ortho uniquement pour permettre des choses plus complètes dans la légende.