### PR TITLE
Fix jour en trop dans l'actualisation des counts projet

### DIFF
--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -191,12 +191,12 @@ if [ -f ${CONFIG.WORK_DIR}/osh_timestamp ]; then
 	cur_timestamp=$(date -Idate --utc)
 	echo "Counting from \$cnt_timestamp"
 
-	days=$cnt_timestamp
-	until [[ \$cnt_timestamp > \$cur_timestamp ]]; do
-		cnt_timestamp=$(date -Idate --utc -d "\$cnt_timestamp + 1 day" )
+	days=""
+	until [[ \$cnt_timestamp>=\$cur_timestamp ]]; do
 		days="\$days \$cnt_timestamp"
+		cnt_timestamp=$(date -Idate --utc -d "\$cnt_timestamp + 1 day" )
 	done
-	days=($days)
+	days=($\{days##*( )\})
 else
     echo "Counting from project start"
 	days=(${getDays().map(d => `"${d}"`).join(" ")})


### PR DESCRIPTION
Petit bug entraînant le calcul de points de stats ultérieurs à la date du jour.

Pour le refresh du 2021-01-01, on avait les points de temps
2020-12-31
2021-01-01
2021-01-02 (carrément)

Maintenant on doit avoir
2020-12-31 seulement