### PR TITLE
Fix noms d'utilisateur en double dans le leaderboard

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -1,9 +1,8 @@
 -- User names
 CREATE TABLE pdm_user_names(
-	project VARCHAR NOT NULL,
 	userid BIGINT NOT NULL,
 	username VARCHAR NOT NULL,
-	CONSTRAINT pdm_user_names_unique PRIMARY KEY(project, userid)
+	CONSTRAINT pdm_user_names_pk PRIMARY KEY(userid)
 );
 
 -- Projects

--- a/db/12_projects_contribs.sql
+++ b/db/12_projects_contribs.sql
@@ -1,10 +1,10 @@
 -- Update user names
 INSERT INTO pdm_user_names
-SELECT DISTINCT ON (userid) project, userid, username
+SELECT DISTINCT ON (userid) userid, username
 FROM pdm_changes
 WHERE userid IS NOT NULL
 ORDER BY userid, ts DESC
-ON CONFLICT (project, userid)
+ON CONFLICT (userid)
 DO UPDATE SET username = EXCLUDED.username;
 
 -- Establishing user contributions in every running project


### PR DESCRIPTION
Suppression de la colonne projet injustement ajouté lors de ma PR sur le suivi des projets en simultané.

Cela causait l'apparition de plusieurs utilisateurs du même nom sur le podium, suivant leur implication dans plusieurs projets ou non

Fix #144 