### PR TITLE
Calcul incremental des contributions

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -28,14 +28,19 @@ CREATE TABLE pdm_changes(
 	username VARCHAR,
 	userid BIGINT,
 	tags JSONB,
-	contrib VARCHAR DEFAULT NULL
+	contrib VARCHAR DEFAULT NULL,
+
+	CONSTRAINT pdm_changes_pk PRIMARY KEY(project,osmid,version)
 );
 
 CREATE INDEX ON pdm_changes(project);
 CREATE INDEX ON pdm_changes(action);
 CREATE INDEX ON pdm_changes(osmid);
 CREATE INDEX ON pdm_changes(version);
+CREATE INDEX ON pdm_changes(ts);
 
+-- Users contributions
+-- No osmid, then no primary key on this table (several contribs can occur at the same ts)
 CREATE TABLE pdm_user_contribs(
 	project VARCHAR NOT NULL,
 	userid BIGINT NOT NULL,
@@ -57,7 +62,7 @@ CREATE TABLE pdm_feature_counts(
 	ts TIMESTAMP NOT NULL,
 	amount INT NOT NULL,
 	
-	UNIQUE(project,ts)
+	CONSTRAINT pdm_feature_counts_pk PRIMARY KEY(project,ts)
 );
 
 CREATE INDEX ON pdm_feature_counts(project);

--- a/db/11_changes_contribs.sql
+++ b/db/11_changes_contribs.sql
@@ -1,4 +1,0 @@
--- Qualification des changements
-UPDATE pdm_changes SET contrib='add' WHERE contrib IS NULL AND version=1;
-
-UPDATE pdm_changes SET contrib='edit' WHERE contrib IS NULL AND version>1;

--- a/db/12_projects_contribs.sql
+++ b/db/12_projects_contribs.sql
@@ -2,19 +2,21 @@
 INSERT INTO pdm_user_names
 SELECT DISTINCT ON (userid) userid, username
 FROM pdm_changes
-WHERE userid IS NOT NULL
+WHERE userid IS NOT NULL AND project=:project_id AND ts BETWEEN :start_date AND :end_date
 ORDER BY userid, ts DESC
 ON CONFLICT (userid)
 DO UPDATE SET username = EXCLUDED.username;
 
 -- Establishing user contributions in every running project
+DELETE FROM pdm_user_contribs WHERE project=:project_id AND ts BETWEEN :start_date AND :end_date;
+
 WITH projectChanges AS (
 	SELECT c.project, c.userid, c.ts, c.contrib AS contribution, pp.points
 	FROM pdm_changes c
 	JOIN pdm_projects p ON p.project=c.project
 	JOIN pdm_projects_points pp ON pp.project=c.project AND c.contrib=pp.contrib
 
-	WHERE c.ts BETWEEN p.start_date AND p.end_date
+	WHERE c.project=:project_id AND c.ts BETWEEN :start_date AND :end_date
 )
 INSERT INTO pdm_user_contribs(project, userid, ts, contribution, points)
 SELECT * FROM projectChanges;


### PR DESCRIPTION
Modifications de l'organisation du script de mise à jour des projets
* Une unique boucle itérant sur les projets désormais (contre deux avant), fusion du filtrage et des stats
* Calcul incrémental des changes et contributions. Le script travaille sur une place de temps bornée, supprime l'existant dans cette plage et n'ajoute que le nécessaire

Avant c'était l'intégralité des changes et contributions qui étaient supprimés puis recréés.

J'ai testé un recalcul complet puis un calcul quotidien et je confirme que 99% des données restent en place au second calcul, gain d'efficacité certain

Drop + create obligatoire des tables suivantes :
* pdm_leaderboard
* pdm_changes
* pdm_feature_counts
* pdm_user_contribs
* pdm_user_names

Fix #143 
Fix #156 

Il restera les notes à inclure à tout ça, tracé dans #161 