### PR TITLE
Fix sur l'heure pour le jour de comptage project

### DIFF
--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -328,7 +328,7 @@ done
 days=($\{days##*( )\})
 for day in "\${days[@]}"; do
 	echo "Processing $day"
-	osmium time-filter "${oshUsefull}" \${day}T00:00:00Z -O -o ${osmStats} -f osm.pbf
+	osmium time-filter "${oshUsefull}" \${day}T23:59:59Z -O -o ${osmStats} -f osm.pbf
 	`;
 	let tagFilterLastPart = tagFilterParts.pop();
 	tagFilterParts.forEach(tagFilter => {


### PR DESCRIPTION
Ce matin j'ai été choqué de ne pas avoir vu apparaitre sur le graph ma contribution de l'avant-veille.

En regardant de plus près, je me suis aperçu que l'heure du jour de filtrage définie dans #154 était définie à 00:00 au lieu de 23:59.