### PR TITLE
Integration des stats geographiques dans project:update

### DIFF
--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -110,9 +110,13 @@ name VARCHAR
 admin_level INT
 tags HSTORE
 geom GEOMETRY(Geometry, 3857)
+centre GEOMETRY(Point, 3857)
 ```
+La colonne `centre` est comprise comme étant un point compris dans le périmètre de la limite (vous pouvez utiliser [ST_PointOnSurface](https://postgis.net/docs/ST_PointOnSurface.html)).
 
-Créer des indexes sur les colonnes osm_id, tags et geometry peut être utile suivant la population d'objets touchée par un projet donné.
+Créer des indexes sur les colonnes `osm_id`, `tags`, `geom` et `centre` peut être utile suivant la population d'objets touchée par un projet donné.
+
+PdM va automatiquement créer une table `pdm_boundary_subdivide` en utilisant [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) pour faciliter le calcul d'intersection entre les objets du projet et le zonage administratif.
 
 ### Sources de données
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -110,9 +110,13 @@ name VARCHAR
 admin_level INT
 tags HSTORE
 geom GEOMETRY(Geometry, 3857)
+centre GEOMETRY(Point, 3857)
 ```
+`centre` column is understood as a point included in the boundary shape (you can use [ST_PointOnSurface](https://postgis.net/docs/ST_PointOnSurface.html))
 
-Create indexes on `osm_id`, `tags` and `geometry` columns might be useful depending of your database content.
+Create indexes on `osm_id`, `tags`, `geom` and `centre` columns might be useful depending of your database content.
+
+PdM will autonomously derivate a `pdm_boundary_subdivide` table with usage of [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) function as to improve features intersection with admin boundaries.
 
 ### Data sources
 

--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -56,7 +56,7 @@ CREATE INDEX ON pdm_user_contribs(userid);
 -- User badges
 DROP TABLE IF EXISTS pdm_user_badges;
 
--- Features counts
+-- Features overall counts
 CREATE TABLE pdm_feature_counts(
 	project VARCHAR NOT NULL,
 	ts TIMESTAMP NOT NULL,
@@ -76,6 +76,34 @@ CREATE TABLE pdm_note_counts(
 );
 
 CREATE INDEX ON pdm_note_counts(project);
+
+-- Statistics per project and administrative boundary
+-- boundary can be null until we'll able to get geometry of deleted features
+CREATE TABLE pdm_features_boundary (
+	project VARCHAR NOT NULL,
+	osmid VARCHAR NOT NULL,
+	boundary BIGINT,
+	start_ts TIMESTAMP NOT NULL,
+	end_ts TIMESTAMP,
+
+	UNIQUE(project,osmid,boundary)
+);
+
+CREATE INDEX ON pdm_features_boundary USING btree(project);
+CREATE INDEX ON pdm_features_boundary USING btree(osmid);
+CREATE INDEX ON pdm_features_boundary USING btree(boundary);
+
+CREATE TABLE pdm_feature_counts_per_boundary(
+	project VARCHAR NOT NULL,
+	boundary BIGINT NOT NULL,
+	ts TIMESTAMP NOT NULL,
+	amount INT NOT NULL,
+
+	CONSTRAINT pdm_feature_counts_per_boundary_pk PRIMARY KEY(project, boundary, ts)
+);
+
+CREATE INDEX ON pdm_feature_counts_per_boundary using btree (project);
+CREATE INDEX ON pdm_feature_counts_per_boundary using btree (boundary);
 
 -- Extensions for Imposm
 CREATE EXTENSION IF NOT EXISTS postgis;
@@ -254,60 +282,3 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql
 IMMUTABLE LEAKPROOF ROWS 100;
-
--- Statistics per project and administrative boundary
-CREATE TABLE pdm_feature_counts_per_boundary(
-	project VARCHAR NOT NULL,
-	boundary BIGINT NOT NULL,
-	day DATE NOT NULL,
-	amount INT NOT NULL,
-
-	CONSTRAINT pdm_feature_counts_per_boundary_pk PRIMARY KEY(project, boundary, day)
-);
-
-CREATE INDEX pdm_feature_counts_per_boundary_project_idx ON pdm_feature_counts_per_boundary(project);
-
--- Count edits per administrative boundary
-CREATE OR REPLACE FUNCTION pdm_add_changes_per_boundary(project_id VARCHAR, start_ts TIMESTAMP, end_ts TIMESTAMP) RETURNS VOID AS $$
-DECLARE
-	curr_day DATE;
-BEGIN
-	curr_day := start_ts::DATE;
-
-	-- Cleanup before counting
-	DELETE FROM pdm_feature_counts_per_boundary
-	WHERE project = project_id AND day BETWEEN start_ts::DATE AND end_ts;
-
-	-- List of edits in each boundary
-	EXECUTE format('
-		CREATE TABLE pdm_boundary_edits_tmp AS
-		SELECT b.osm_id, b.name, f.day AS edit_day
-		FROM (
-			SELECT DISTINCT ON (c.osmid) c.osmid, c.ts::date AS day, c.action, p.geom
-			FROM pdm_changes c
-			JOIN %I p ON c.osmid = p.osm_id
-			WHERE c.project = %L AND c.ts BETWEEN %L AND %L
-			ORDER BY c.osmid, c.version DESC
-		) f
-		JOIN pdm_boundary b ON f.geom && b.geom AND ST_Intersects(f.geom, b.geom)
-	', 'pdm_project_' || substring(project_id, 9), project_id, start_ts, end_ts);
-	CREATE INDEX pdm_boundary_edits_tmp_edit_day_idx ON pdm_boundary_edits_tmp(edit_day);
-
-	-- Count added features each day
-	WHILE curr_day <= end_ts LOOP
-		INSERT INTO pdm_feature_counts_per_boundary(project, boundary, day, amount)
-		SELECT project_id, osm_id, curr_day, amount
-		FROM (
-			SELECT osm_id, COUNT(*) AS amount
-			FROM pdm_boundary_edits_tmp
-			WHERE edit_day <= curr_day
-			GROUP BY osm_id
-		) a;
-		curr_day := curr_day + '1 day'::interval;
-	END LOOP;
-
-	DROP TABLE pdm_boundary_edits_tmp;
-	REINDEX TABLE pdm_feature_counts_per_boundary;
-END;
-$$ LANGUAGE plpgsql
-LEAKPROOF;

--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -29,7 +29,6 @@ const OSC2CSV = __dirname+'/osc2csv.xslt';
 const OSC_USEFULL = CONFIG.WORK_DIR + '/extract_filtered.osc.gz';
 const OSC_UPDATES = CONFIG.WORK_DIR + '/changes.osc.gz';
 
-const CSV_COUNT = CONFIG.WORK_DIR + '/count.csv';
 const CSV_CHANGES = CONFIG.WORK_DIR + '/change.csv';
 const CSV_NOTES = CONFIG.WORK_DIR + '/notes.csv';
 const CSV_NOTES_CONTRIBS = CONFIG.WORK_DIR + '/user_notes.csv';
@@ -230,9 +229,6 @@ ${separator}
 `;
 }
 
-script += `
-rm -rf "${CSV_COUNT}"`;
-
 const projectsToProcess = runForAll ? Object.values(projects) : projectsFold.current;
 projectsToProcess.forEach(project => {
 	let oshInput = OSH_UPDATED;
@@ -283,11 +279,10 @@ ${PSQL} -c "DELETE FROM pdm_changes WHERE project='${project.id}' AND ts BETWEEN
 
 ${PSQL} -c "CREATE TABLE IF NOT EXISTS pdm_changes_tmp (LIKE pdm_changes)"
 ${PSQL} -c "TRUNCATE TABLE pdm_changes_tmp"
+
 ${PSQL} -c "\\COPY pdm_changes_tmp (project, action, osmid, version, ts, username, userid, tags) FROM '${CSV_CHANGES}' CSV"
-${PSQL} -c "UPDATE pdm_changes_tmp SET contrib='add' WHERE contrib IS NULL AND version=1"
-${PSQL} -c "UPDATE pdm_changes_tmp SET contrib='edit' WHERE contrib IS NULL AND version>1"
-${PSQL} -c "INSERT INTO pdm_changes SELECT * FROM pdm_changes_tmp ON CONFLICT (project,osmid,version) DO UPDATE SET tags=EXCLUDED.tags, ts=EXCLUDED.ts, username=EXCLUDED.username, action=EXCLUDED.action"
-${PSQL} -c "DROP TABLE pdm_changes_tmp"
+
+${PSQL} -v project_id="'${project.id}'" -v project_table="pdm_project_${project.id.split("_").pop()}" -f "${__dirname}/13_changes_populate.sql"
 
 if [ -f "${__dirname}/../projects/${project.id}/contribs.sql" ]; then
 	echo "Including project custom contributions"
@@ -296,9 +291,7 @@ fi
 
 rm -f "${CSV_CHANGES}"
 ${separator}
-`;
 
-	script += `
 echo "== Statistics for project ${project.id}"`;
 	let osmStats = OSH_USEFULL.replace("usefull.osh.pbf", `${project.id.split("_").pop()}.stats.osm.pbf`);
 	let osmStatsFiltered = OSH_USEFULL.replace("usefull.osh.pbf", `${project.id.split("_").pop()}.filtered.stats.osm.pbf`);
@@ -308,6 +301,7 @@ echo "== Statistics for project ${project.id}"`;
 		script += `
 echo "   => Count features"
 ${PSQL} -c "DELETE FROM pdm_feature_counts WHERE project='${project.id}' AND ts BETWEEN '\${cnt_timestamp}T00:00:00Z' AND '\${cur_timestamp}T00:00:00Z'"
+${PSQL} -c "DELETE FROM pdm_feature_counts_per_boundary WHERE project='${project.id}' AND ts BETWEEN '\${cnt_timestamp}T00:00:00Z' AND '\${cur_timestamp}T00:00:00Z'"
 
 echo "Counting from \$cnt_timestamp"
 days=""
@@ -319,7 +313,7 @@ done
 days=($\{days##*( )\})
 for day in "\${days[@]}"; do
 	echo "Processing $day"
-	osmium time-filter "${oshUsefull}" \${day}T23:59:59Z -O -o ${osmStats} -f osm.pbf
+	osmium time-filter "${oshUsefull}" \${day}T23:59:59Z --no-progress -O -o ${osmStats} -f osm.pbf
 	`;
 	let tagFilterLastPart = tagFilterParts.pop();
 	tagFilterParts.forEach(tagFilter => {
@@ -333,7 +327,9 @@ for day in "\${days[@]}"; do
 	if [ "$nbday" == "" ]; then
 		nbday="0"
 	fi
-	echo "${project.id},$day,$nbday" >> "${CSV_COUNT}"
+
+	${PSQL} -c "INSERT INTO pdm_feature_counts (project,ts,amount) VALUES ('${project.id}', '\${day}T23:59:59Z', \${nbday}) ON CONFLICT (project,ts) DO UPDATE SET amount=EXCLUDED.amount"
+	${PSQL} -c "INSERT INTO pdm_feature_counts_per_boundary(project, boundary, ts, amount) SELECT '${project.id}' as project, boundary, '\${day}T23:59:59Z' AS ts, count(*) as amount FROM pdm_features_boundary WHERE project='${project.id}' AND ('\${day}T23:59:59Z' BETWEEN start_ts AND end_ts OR (start_ts is null and end_ts is null) OR '\${day}T23:59:59Z' > start_ts OR '\${day}T23:59:59Z' < end_ts) GROUP BY project, boundary ON CONFLICT (project,boundary,ts) DO UPDATE SET amount=EXCLUDED.amount"
 done
 rm -f "${osmStats}"
 `;
@@ -365,20 +361,9 @@ rm -f "${CSV_NOTES}" "${CSV_NOTES_CONTRIBS}" "${CSV_NOTES_USERS}"`;
 });
 
 script += `
-if [[ -f "${CSV_COUNT}" ]] && [[ $(wc -l "${CSV_COUNT}")>0 ]]; then
-	${PSQL} -c "CREATE TABLE IF NOT EXISTS pdm_feature_counts_tmp (LIKE pdm_feature_counts)"
-	${PSQL} -c "TRUNCATE TABLE pdm_feature_counts_tmp"
-	${PSQL} -c "\\COPY pdm_feature_counts_tmp FROM '${CSV_COUNT}' CSV"
-	${PSQL} -c "INSERT INTO pdm_feature_counts SELECT * FROM pdm_feature_counts_tmp ON CONFLICT (project,ts) DO UPDATE SET amount=EXCLUDED.amount"
-	${PSQL} -c "DROP TABLE pdm_feature_counts_tmp"
-fi
-rm -f "${CSV_COUNT}"
-
 echo "== Optimize database"
-if [ -f ${CONFIG.WORK_DIR}/osh_timestamp ]; then
-	${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_tiles"
-fi
 ${PSQL} -c "REINDEX DATABASE ${CONFIG.DB_NAME}"
+${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_tiles"
 ${separator}
 
 rm -f "${CONFIG.WORK_DIR}/osh_timestamp"

--- a/db/12_projects_contribs.sql
+++ b/db/12_projects_contribs.sql
@@ -23,6 +23,3 @@ SELECT * FROM projectChanges;
 
 -- Reindex for performance
 REINDEX TABLE pdm_user_contribs;
-
--- Add statistics about nb of features in every admin boundary
-SELECT pdm_add_changes_per_boundary(:project_id, :start_date, :end_date);

--- a/db/13_changes_populate.sql
+++ b/db/13_changes_populate.sql
@@ -1,0 +1,42 @@
+-- Features changes population script
+
+-- Update actions
+UPDATE pdm_changes_tmp SET contrib='add' WHERE contrib IS NULL AND version=1;
+UPDATE pdm_changes_tmp SET contrib='edit' WHERE contrib IS NULL AND version>1 AND action='modify';
+UPDATE pdm_changes_tmp SET contrib='delete' WHERE contrib IS NULL AND version>1 AND action='delete';
+
+-- Insert changes
+INSERT INTO pdm_changes
+  SELECT *
+  FROM pdm_changes_tmp
+  ON CONFLICT (project,osmid,version)
+    DO UPDATE SET tags=EXCLUDED.tags, ts=EXCLUDED.ts, username=EXCLUDED.username, action=EXCLUDED.action;
+
+-- Insert unknown features and associate them with enclosing boundaries
+WITH unknown AS (
+  SELECT p.osm_id AS osmid, b.osm_id AS boundary
+  FROM :project_table p
+  LEFT JOIN pdm_features_boundary fb ON fb.project=:project_id AND fb.osmid=p.osm_id
+  JOIN pdm_boundary_subdivide b ON ST_Intersects(p.geometry, b.geom)
+  WHERE fb.osmid IS NULL
+  GROUP BY p.osm_id, b.osm_id
+)
+INSERT INTO pdm_features_boundary 
+  SELECT :project_id AS project, u.osmid AS osmid, u.boundary, '2004-01-01T00:00:00' AS start_ts
+  FROM unknown u;
+
+-- Update start and end dates for each features according to changes
+WITH changes AS (SELECT c.project, c.osmid, 
+  CASE WHEN c.action='create' THEN c.ts ELSE NULL END AS start_ts,
+  CASE WHEN c.action='delete' THEN c.ts ELSE NULL END AS end_ts
+  FROM pdm_changes_tmp c
+  WHERE c.project=:project_id
+), features AS (
+  SELECT project, osmid, MAX(start_ts) AS start_ts, MAX(end_ts) AS end_ts
+  FROM changes
+  GROUP BY osmid, project
+)
+UPDATE pdm_features_boundary b SET start_ts=COALESCE(f.start_ts, b.start_ts), end_ts=COALESCE(f.end_ts, b.end_ts) FROM features f WHERE b.project=f.project AND b.osmid=f.osmid;
+
+-- Drop temp tables
+DROP TABLE pdm_changes_tmp;

--- a/db/22_features_post_init.sql
+++ b/db/22_features_post_init.sql
@@ -1,13 +1,21 @@
+-- Boundary subdivide
+CREATE MATERIALIZED VIEW pdm_boundary_subdivide AS 
+SELECT id, osm_id, type, name, admin_level, tags, ST_Subdivide(geom, 450) AS geom
+FROM pdm_boundary;
+
+  CREATE INDEX ON pdm_boundary_subdivide using gist(geom);
+  CREATE INDEX ON pdm_boundary_subdivide using btree(osm_id);
+
 -- Boundary stats for tiles
 CREATE MATERIALIZED VIEW pdm_boundary_tiles AS
 SELECT
 	s.project, s.boundary, b.name, b.admin_level,
-	json_object(array_agg(s.day::text), array_agg(s.amount::text)) AS stats,
+	json_object(array_agg(s.ts::date::text), array_agg(s.amount::text)) AS stats,
 	MAX(s.amount) AS nb,
-	ST_PointOnSurface(b.geom)::GEOMETRY(Point, 3857) AS geom
+	b.centre AS geom
 FROM pdm_feature_counts_per_boundary s
 JOIN pdm_boundary b ON s.boundary = b.osm_id
-GROUP BY s.project, s.boundary, b.name, b.admin_level, b.geom
+GROUP BY s.project, s.boundary, b.name, b.admin_level, b.centre
 ORDER BY s.project, b.admin_level;
 
 CREATE INDEX pdm_boundary_tiles_project_idx ON pdm_boundary_tiles(project);


### PR DESCRIPTION
Intégration du calcul des stats géographiques dans l'itération existante de calcul des stats globales.
* Persistance des associations features/boundaries (et mise à jour incrémentale) dans la table pdm_features_boundary
* Suppression du fichier csv_counts (on s'économise des écritures disque)
* Mutualisation de la table pdm_changes_tmp qui permet à la fois d'avoir les changes globaux et d'assigner les features concernées aux boundaries
* Ajout des boundaries subdivide pour maîtriser le temps de calcul sur des projets avec beaucoup d'objets

Il reste quelques problèmes
* Les suppressions d'objets ne sont pas proprement gérés pour l'instant
* Refresh de la vue pdm_boundary_tiles suuuuuuuuuuper long (plus de 10 minutes)

Fix #184 
Fix #186 