### PR TITLE
Add Nodejs Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /db/*_tmp.sql
 /db/13_points.sql
 /.idea
+/osmium

--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -28,32 +28,12 @@ Les paquets suivants pourront être utiles pour cela
 * libboost-dev
 * libboost-program-options-dev
 
-## Installation
+## Débuter
 
 ```bash
 git clone https://github.com/vdct/ProjetDuMois.git
 cd ProjetDuMois
 git submodule update --init
-```
-Choisissez ensuite entre une instance Docker ou locale pour poursuivre.  
-Confère à la section Déploiement ci-dessous pour obtenir un ProjetDuMois exploitable.
-
-### Construction Docker
-
-Il est possible de construire un serveur node.js unique pourvu des fonctionnalités nécessaires à toute l'exploitation. Il inclus osmium 1.10.0 avec Debian Buster.  
-L'image Docker n'inclue cependant pas de serveur postgresql et vous pourrez utiliser [l'image de CampToCamp](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
-
-```bash
-docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
-```
-
-Avec :
-* IMPOSM3_VERSION : Version d'imposm3 à intégrer à l'image Docker
-
-### Installation locale
-
-```bash
-npm install
 ```
 
 ## Configuration générale
@@ -269,11 +249,40 @@ Les montant de points attribués sont configurés dans `info.json` :
 }
 ```
 
+## Installation
+
+Choisissez ensuite entre une instance Docker ou locale pour poursuivre.  
+Confère à la section Déploiement ci-dessous pour obtenir un ProjetDuMois exploitable.
+
+### Construction Docker
+
+Il est possible de construire un serveur node.js unique pourvu des fonctionnalités nécessaires à toute l'exploitation. Il inclus osmium 1.10.0 avec Debian Buster.  
+L'image Docker n'inclue cependant pas de serveur postgresql et vous pourrez utiliser [l'image de CampToCamp](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
+
+```bash
+docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
+```
+
+Avec :
+* IMPOSM3_VERSION : Version d'imposm3 à intégrer à l'image Docker
+
+### Installation locale
+
+```bash
+npm install
+```
+
 ## Déploiement
 
 ### Base de données
 
-#### Docker
+The database relies on PostgreSQL. To create the database :
+
+```bash
+psql -c "CREATE DATABASE pdm"
+```
+
+### Docker
 
 Le service s'installe avec les deux commandes suivantes :
 
@@ -282,7 +291,7 @@ docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host
 docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest init
 ```
 
-And then run the server with:
+Ensuite, lancez le serveur avec la commande :
 ```bash
 docker run -d --rm [--network=your-network -p 3000:3000] --name=pdm -v host_work_dir:container_work_dir -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest run
 ```
@@ -292,7 +301,7 @@ N'oubliez pas d'ajouter la ligne suivante dans vos crontab pour mettre à jour l
 docker exec -it pdm /opt/pdm/db/09_project_update_tmp.sh
 ```
 
-#### Locale
+### Locale
 
 La base de données s'appuie sur PostgreSQL. Pour installer la base :
 

--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -2,16 +2,31 @@
 
 ## Dépendances
 
-* NodeJS >= 9
+* NodeJS >= 12.9
 * Outils Bash : curl, awk, grep, sed, xsltproc, bc
 * PostgreSQL >= 10
 * Python 3
-* [Osmium](https://osmcode.org/osmium-tool/)
+* [Osmium](https://osmcode.org/osmium-tool/) > 1.10
 * [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)
 * [Imposm](https://imposm.org/) >= 3
 * [pg_tileserv](https://github.com/CrunchyData/pg_tileserv)
 * Dépendances de [sendfile_osm_oauth_protector](https://github.com/geofabrik/sendfile_osm_oauth_protector#requirements)
 
+### Compilation osmium
+
+ProjetDuMois a besoin d'une version récente de osmium puisqu'il tire parti des nouvelles fonctions tags-filter.  
+Peu de distributions linux ont les dernières versions disponibles et vous aurez surement besoin de compiler osmium vous-même.
+
+Voir les consignes sur le [README officiel](https://github.com/osmcode/osmium-tool/blob/master/README.md#building).
+
+Les paquets suivants pourront être utiles pour cela
+* build-essential
+* cmake
+* zlib1g-dev
+* libbz2-dev
+* liblz4-dev
+* libboost-dev
+* libboost-program-options-dev
 
 ## Installation
 
@@ -19,9 +34,27 @@
 git clone https://github.com/vdct/ProjetDuMois.git
 cd ProjetDuMois
 git submodule update --init
-npm install
+```
+Choisissez ensuite entre une instance Docker ou locale pour poursuivre.  
+Confère à la section Déploiement ci-dessous pour obtenir un ProjetDuMois exploitable.
+
+### Construction Docker
+
+Il est possible de construire un serveur node.js unique pourvu des fonctionnalités nécessaires à toute l'exploitation. Il inclus osmium 1.10.0 avec Debian Buster.  
+L'image Docker n'inclue cependant pas de serveur postgresql et vous pourrez utiliser [l'image de CampToCamp](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
+
+```bash
+docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
 ```
 
+Avec :
+* IMPOSM3_VERSION : Version d'imposm3 à intégrer à l'image Docker
+
+### Installation locale
+
+```bash
+npm install
+```
 
 ## Configuration générale
 
@@ -32,9 +65,6 @@ La configuration générale de l'outil est à renseigner dans `config.json`. Un 
 * `OSM_API_KEY` : clé d'API OSM
 * `OSM_API_SECRET` : secret lié à la clé d'API OSM
 * `OSH_PBF_URL` : URL du fichier OSH.PBF (historique et métadonnées, exemple `https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf`)
-* `DB_NAME` : nom de la base PostgreSQL (exemple `pdm`)
-* `DB_HOST` : nom d'hôte de la base PostgreSQL (exemple `localhost`)
-* `DB_PORT` : numéro de port de la base PostgreSQL (exemple `5432`)*
 * `DB_USE_IMPOSM_UPDATE` : Active ou désactive l'intégration d'imposm3 (permet d'utiliser une base existante et tenue à jour par d'autres moyens, par défaut `true`)
 * `WORK_DIR` : dossier de téléchargement et stockage temporaire (doit pouvoir contenir le fichier OSH PBF, exemple `/tmp/pdm`)
 * `OSM_URL` : instance OpenStreetMap à utiliser (exemple `https://www.openstreetmap.org`)
@@ -51,10 +81,14 @@ La configuration générale de l'outil est à renseigner dans `config.json`. Un 
 
 ### Connexion à Postgresql
 
-Aucun identifiant ni mot de passe ne sont ajoutés à la configuration de l'application.
-Ajoutez un fichier ~/.pgpass (chmod 600) pour l'utilisateur applicatif afin de permettre à psql ou ses dépendances de s'authentifier.
+Pour se connecter à Postgresql, une variable d'environement `DB_URL` est attendue avec une chaine conninfo pour disposer des informations nécessaires.
+Ceci est valable quelle que soit la solution retenue, docker ou locale.
 
-Voir https://www.postgresql.org/docs/current/libpq-pgpass.html
+```bash
+export DB_URL="postgres://user:password@host:5432/database"
+```
+
+Reportez-vous au chapitre 33.1.1 du [guide postgresql](https://www.postgresql.org/docs/13/libpq-connect.html).
 
 ## Configuration des projets
 
@@ -235,13 +269,34 @@ Les montant de points attribués sont configurés dans `info.json` :
 }
 ```
 
+## Déploiement
 
-## Base de données
+### Base de données
 
-La base de données s'appuie sur PostgreSQL. Pour créer la base :
+#### Docker
+
+Le service s'installe avec les deux commandes suivantes :
 
 ```bash
-psql -c "CREATE DATABASE pdm"
+docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest install
+docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest init
+```
+
+And then run the server with:
+```bash
+docker run -d --rm [--network=your-network -p 3000:3000] --name=pdm -v host_work_dir:container_work_dir -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest run
+```
+
+N'oubliez pas d'ajouter la ligne suivante dans vos crontab pour mettre à jour les projets périodiquement, idéalement quotidiennement.
+```bash
+docker exec -it pdm /opt/pdm/db/09_project_update_tmp.sh
+```
+
+#### Locale
+
+La base de données s'appuie sur PostgreSQL. Pour installer la base :
+
+```bash
 psql -d pdm -f db/00_init.sql
 ```
 
@@ -266,19 +321,9 @@ npm run features:update
 ./db/21_features_update_tmp.sh
 ```
 
-
 ## Site web
 
 Le code de l'interface web se trouve dans le dossier `website`. Il s'agit d'un serveur [ExpressJS](http://expressjs.com/), combiné à des modèles [Pug](https://pugjs.org).
-
-Pour lancer le site web :
-
-```bash
-export PGUSER=`whoami` # Nom d'utilisateur pour accéder à la base de données
-npm run start
-```
-
-Le site est visible à l'adresse [localhost:3000](http://localhost:3000).
 
 Les modèles Pug sont dans le sous-dossier `templates`. Celui-ci est organisé selon la logique suivante :
 
@@ -286,3 +331,46 @@ Les modèles Pug sont dans le sous-dossier `templates`. Celui-ci est organisé s
 * Dans `common`, les éléments génériques à toutes les pages (`<head>`, en-tête, pied de page)
 * Dans `components`, les composants principaux qui peuplent les pages (carte, bloc statistiques...)
 * Dans `pages`, chacune des pages du site (accueil, carte, page projet...)
+
+Le site est visible à l'adresse [localhost:3000](http://localhost:3000).
+
+### Docker
+
+L'image Docker inclue le nécessaire pour servir le site web et executer les tâches de mise à jour automatiques.  
+Vous pouvez la lancer avec:
+
+```bash
+docker run -p 3000:3000 [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest
+```
+
+### Docker compose
+
+Un fichier docker-compose est fourni ici pour faciliter l'execution de la plateforme. Cela ne vous dispensera pas de créer la base de données, y ajouter les bons rôles et configurer pdm de manière appropriée selon la méthode expliquée ci-dessus.  
+Docker-compose permet seulement de faciliter l'execution d'une instance déjà fonctionnelle si et seulement si elle a été configurée correctement préalablement.
+
+En fonction de la configuration de votre serveur Postgresql, vous devrez certainement adapter la valeur de la variable `DB_URL` dans le fichier compose pour permettre au serveur pdm d'accéder à la base de données correctement.
+
+N'essayez pas de débuter la configuration d'une instance avec docker-compose, essayez plutôt d'obtenir une configuration fonctionnelle de chaque composant et de vous assurer que tout fonctionne séparément d'abord.  
+Une fois que vous avez constaté que tout fonctionnait, lancez-vous avec docker-compose pour faciliter les executions futures.
+
+Pour démarrer :
+```
+docker-compose up
+```
+
+Pour arrêter :
+```
+docker-compose down
+```
+
+### Locale
+
+L'execution locale nécessite un serveur node conforme à la compatilité ci-dessus et des tâches planifiées pour tenir la base de données à jour.
+
+Pour lancer le site web :
+
+```bash
+export DB_URL=`postgres://user:password@host:5432/database` # Database URL
+export PORT=3000 # Nodejs port (defaults to 3000)
+npm run start
+```

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -28,33 +28,12 @@ Following packets on debian can be useful
 * libboost-dev
 * libboost-program-options-dev
 
-## Installation
+## Getting started
 
 ```bash
 git clone https://github.com/vdct/ProjetDuMois.git
 cd ProjetDuMois
 git submodule update --init
-```
-
-Then choose between Docker or standalone to continue with installation.  
-Refers to Database section below to make ProjetDuMois fully runable.
-
-### Docker build
-
-You can build a node.js based ProjetDuMois server including necessary features to run. It includes osmium 1.10.0 with Debian Buster.
-It doesn't includes a PgSQL server. You can use [CampToCamp Postgres image](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
-
-```bash
-docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
-```
-
-Where:
-* IMPOSM3_VERSION: Version of imposm3 to use in the docker image
-
-### Standalone instance
-
-```bash
-npm install
 ```
 
 ## General configuration
@@ -270,6 +249,29 @@ Configuration of points is in `info.json`:
 }
 ```
 
+## Build
+
+Once PDM has been properly configured, you should choose between Docker or standalone to build it. 
+Refers to Database section in run chapter to make ProjetDuMois fully runable.
+
+### Docker build
+
+You can build a node.js based ProjetDuMois server including necessary features to run. It includes osmium 1.10.0 with Debian Buster.
+It doesn't includes a PgSQL server. You can use [CampToCamp Postgres image](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
+
+```bash
+docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
+```
+
+Where:
+* IMPOSM3_VERSION: Version of imposm3 to use in the docker image
+
+### Standalone instance
+
+```bash
+npm install
+```
+
 ## Run
 
 ### Database
@@ -300,6 +302,11 @@ docker exec -it pdm /opt/pdm/db/09_project_update_tmp.sh
 ```
 
 ### Standalone
+
+Database relies on PostgreSQL. To install the schema before first run: 
+```bash
+psql -d pdm -f db/00_init.sql
+```
 
 The following script has to be launched daily to retrieve the contribution statistics (notes, objects added, badges obtained):
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,16 +2,31 @@
 
 ## Dependencies
 
-* NodeJS >= 9
+* NodeJS >= 12.9
 * Bash tools : curl, awk, grep, sed, xsltproc, bc
 * PostgreSQL >= 10
-* Python 3
-* [Osmium](https://osmcode.org/osmium-tool/)
+* Python 3 (and `requests` module)
+* [Osmium](https://osmcode.org/osmium-tool/) > 1.10
 * [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)
 * [Imposm](https://imposm.org/) >= 3
 * [pg_tileserv](https://github.com/CrunchyData/pg_tileserv)
 * Dependencies of [sendfile_osm_oauth_protector](https://github.com/geofabrik/sendfile_osm_oauth_protector#requirements)
 
+### Osmium building
+
+ProjetDuMois requires a recent version of osmium as it takes advantage to newest tags-filter abilities.  
+Not many Linux distros got the appropriate package available in their repositories and you may need to build your own binary of osmium.
+
+See guidelines on the [official README](https://github.com/osmcode/osmium-tool/blob/master/README.md#building). 
+
+Following packets on debian can be useful
+* build-essential
+* cmake
+* zlib1g-dev
+* libbz2-dev
+* liblz4-dev
+* libboost-dev
+* libboost-program-options-dev
 
 ## Installation
 
@@ -19,9 +34,28 @@
 git clone https://github.com/vdct/ProjetDuMois.git
 cd ProjetDuMois
 git submodule update --init
-npm install
 ```
 
+Then choose between Docker or standalone to continue with installation.  
+Refers to Database section below to make ProjetDuMois fully runable.
+
+### Docker build
+
+You can build a node.js based ProjetDuMois server including necessary features to run. It includes osmium 1.10.0 with Debian Buster.
+It doesn't includes a PgSQL server. You can use [CampToCamp Postgres image](https://hub.docker.com/r/camptocamp/postgres/tags?page=1&ordering=last_updated).
+
+```bash
+docker build [--build-arg IMPOSM3_VERSION=0.11.0] -t pdm/server:latest .
+```
+
+Where:
+* IMPOSM3_VERSION: Version of imposm3 to use in the docker image
+
+### Standalone instance
+
+```bash
+npm install
+```
 
 ## General configuration
 
@@ -32,9 +66,6 @@ The general configuration of the tool is to be filled in `config.json`. There is
 * `OSM_API_KEY`: OSM API key
 * `OSM_API_SECRET`: secret linked to the OSM API key
 * `OSH_PBF_URL`: URL of the OSH.PBF file (history and metadata, example `https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf`)
-* `DB_NAME`: name of the PostgreSQL database (example `pdm`)
-* `DB_HOST`: hostname of the PostgreSQL database (example `localhost`)
-* `DB_PORT`: port number of the PostgreSQL database (example `5432`)
 * `DB_USE_IMPOSM_UPDATE` : enable or disabled Imposm3 integration (to use an existing database which would be maintained by other means, by default `true`)
 * `WORK_DIR`: download and temporary storage folder (must have capacity to store the OSH PBF file, example `/tmp/pdm`)
 * `OSM_URL`: OpenStreetMap instance to use (example `https://www.openstreetmap.org`)
@@ -51,10 +82,14 @@ The general configuration of the tool is to be filled in `config.json`. There is
 
 ### Postgresql connection
 
-No user or password are defined in application configuration. Create a `~/.pgpass` file for application user to allow psql or its dependencies to login.
+As to connect to any Postgresql host, `DB_URL` environement variable is expected to be set with a conninfo string.  
+This is necessary for standalone or Docker environments.
 
-See also https://www.postgresql.org/docs/current/libpq-pgpass.html
+```bash
+export DB_URL="postgres://user:password@host:5432/database"
+```
 
+See also 33.1.1 chapter about [Postgresql conninfo strings](https://www.postgresql.org/docs/13/libpq-connect.html).
 
 ## Project configuration
 
@@ -235,15 +270,36 @@ Configuration of points is in `info.json`:
 }
 ```
 
+## Run
 
-## Database
+### Database
 
 The database relies on PostgreSQL. To create the database :
 
 ```bash
 psql -c "CREATE DATABASE pdm"
-psql -d pdm -f db/00_init.sql
 ```
+
+### Docker
+
+Database is installed and inited simply with:
+
+```bash
+docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest install
+docker run --rm [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest init
+```
+
+And then run the server with:
+```bash
+docker run -d --rm [--network=your-network -p 3000:3000] --name=pdm -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest run
+```
+
+Don't forget to add the following in your crontab to periodically update projects
+```bash
+docker exec -it pdm /opt/pdm/db/09_project_update_tmp.sh
+```
+
+### Standalone
 
 The following script has to be launched daily to retrieve the contribution statistics (notes, objects added, badges obtained):
 
@@ -266,19 +322,9 @@ npm run features:update
 ./db/21_features_update_tmp.sh
 ```
 
-
 ## Website
 
 The code for the web interface can be found in the `website` folder. This is an [ExpressJS](http://expressjs.com/) server, combined with [Pug](https://pugjs.org) templates.
-
-To launch the web site :
-
-```bash
-export PGUSER=`whoami` # Database username
-npm run start
-```
-
-The site can be viewed at [localhost:3000](http://localhost:3000).
 
 The Pug templates are in the `templates` sub-folder. It is organized according to the following logic:
 
@@ -286,3 +332,48 @@ The Pug templates are in the `templates` sub-folder. It is organized according t
 * In `common`, generic elements to all pages (`<head>`, header, footer)
 * In `components`, the main components that populate the pages (map, statistics block...)
 * In `pages`, each page of the site (home, map, project page...)
+
+The site can be viewed at [localhost:3000](http://localhost:3000).
+
+### Docker
+
+Docker image includes websites and background updating tasks.  
+You can run it with:
+
+```bash
+docker run -p 3000:3000 [--network=your-network] -e DB_URL=postgres://user:password@host:5432/database pdm/server:latest
+```
+
+### Docker compose
+
+A compose file is provided to ease the running processing. It won't prevent you from creating database, adding users and make the appropriate configuration nor building dockers as mentionned upside.  
+Docker compose only allows to run easilly a functionnal instance if and only it has already been properly configured before.
+
+Depending on your Postgresql configuration, you'll surely have to customize the `DB_URL` env variable in the compose file to let the pdm server access the database safely.
+
+Don't try to run the instance with docker-compose first, try to run each component separately and check if everything work as expected.  
+Once everything runs normally, you can use the following for further runs:
+
+To start:
+```
+docker-compose up
+```
+
+To stop:
+```
+docker-compose down
+```
+
+### Standalone
+
+Standalone running requires a node server complient with compatility at the top of this document and planned tasks to update projects regularly.
+
+To launch the web site :
+
+```bash
+export DB_URL=`postgres://user:password@host:5432/database` # Database URL
+export PORT=3000 # Nodejs port (defaults to 3000)
+npm run start
+```
+
+The site can be viewed at [localhost:3000](http://localhost:3000).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM node:14.18.0-bullseye-slim
+
+RUN groupadd --gid 10001 -r osm \
+    && useradd --uid 10001 -d /home/osm -m -r -s /bin/false -g osm osm \
+    && mkdir -p /data/files/pdm /opt/pdm /opt/imposm3 \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends \
+        apt-utils curl xsltproc osmctools ca-certificates gnupg \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install postgresql-client-13 libpq-dev libgeos-dev osmium-tool python3 python3-requests \
+    && apt-get clean \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG IMPOSM3_VERSION=0.11.0
+
+WORKDIR /opt/imposm3
+
+RUN curl -L https://github.com/omniscale/imposm3/releases/download/v${IMPOSM3_VERSION}/imposm-${IMPOSM3_VERSION}-linux-x86-64.tar.gz -o imposm3.tar.gz \
+    && tar -xvf imposm3.tar.gz --strip 1 \
+    && rm -f imposm3.tar.gz
+
+WORKDIR /opt/pdm
+
+COPY --chown=osm:osm ./db/ ./db
+COPY --chown=osm:osm ./projects ./projects
+COPY --chown=osm:osm ./website ./website
+COPY --chown=osm:osm ./lib ./lib
+COPY --chown=osm:osm ./config.json ./config.json
+COPY --chown=osm:osm ./package.json ./package.json
+
+RUN npm install
+
+COPY --chown=osm:osm dockerfiles/docker-entrypoint.sh README.md ./
+
+RUN chmod +x ./docker-entrypoint.sh \
+    && chown -R osm:osm /data/files/pdm \
+    && chmod -R 755 /data/files/pdm
+
+USER osm
+
+ENV DB_URL=postgres://localhost:5432/osm
+ENV PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/config.example.json
+++ b/config.example.json
@@ -13,9 +13,6 @@
 	"OSH_PBF_URL": "https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf",
 	"MAPBOX_STYLE": "https://tile-vect.openstreetmap.fr/styles/liberty/style.json",
 	"PDM_TILES_URL": "http://localhost:7800",
-	"DB_HOST": "localhost",
-	"DB_PORT": "5432",
-	"DB_NAME": "pdm",
 	"DB_USE_IMPOSM_UPDATE": true,
 	"WORK_DIR": "/tmp/pdm",
 	"GEOJSON_BOUNDS": {

--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -35,16 +35,14 @@ const CSV_NOTES_CONTRIBS = CONFIG.WORK_DIR + '/user_notes.csv';
 const CSV_NOTES_USERS = CONFIG.WORK_DIR + '/usernames_notes.csv';
 
 const COOKIES = CONFIG.WORK_DIR + '/cookie.txt';
-const PSQL = `psql "postgres://@${CONFIG.DB_HOST}:${CONFIG.DB_PORT}/${CONFIG.DB_NAME}"`;
+const PSQL = `psql -d ${process.env.DB_URL}`;
 const OUTPUT_SCRIPT = __dirname+'/09_project_update_tmp.sh';
 const HAS_BOUNDARY = `${PSQL} -c "SELECT * FROM pdm_boundary LIMIT 1" > /dev/null 2>&1 `;
 
 const runForAll = process.argv.slice(2).pop() === "all";
 
 const pgPool = new Pool({
-	host: CONFIG.DB_HOST,
-	database: CONFIG.DB_NAME,
-	port: CONFIG.DB_PORT
+	connectionString: `${process.env.DB_URL}`
 });
 
 // Notes statistics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  pgsqldb:
+    image: camptocamp/postgres:13-postgis-3
+    restart: always
+    networks:
+      - oim-internal
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=pgpassword
+      
+  pdm:
+    image: pdm/server:latest
+    restart: always
+    depends_on:
+      - pgsqldb
+    networks:
+      - oim-internal
+    ports:
+      - "3000:3000"
+    volumes:
+      - pdm-data:/data/files/pdm
+    environment:
+      - DB_URL=postgres://user:password@pgsqldb:5432/database
+    command: "run"
+
+volumes:
+  db-data:
+  pdm-data:
+
+networks:
+  oim-internal:

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+command=${1}
+
+if [ -z $DB_URL ]; then
+    echo "Required env variable DB_URL should be set to reach pgsql backend"
+    exit 1
+fi
+
+echo "Executing ${command} command"
+
+case $command in
+"install")
+    psql -d $DB_URL -f ./db/00_init.sql
+    ;;
+"init")
+    npm run feature:update
+    ./db/21_features_update_tmp.sh
+    ;;
+"run")
+    npm run project:update
+    npm run start
+    ;;
+*)
+    echo "Command $command unknown"
+    exit 2
+    ;;
+esac

--- a/website/index.js
+++ b/website/index.js
@@ -18,9 +18,7 @@ const { I18n } = require('i18n');
  * Connect to database
  */
 const pool = new Pool({
-  host: CONFIG.DB_HOST,
-  database: CONFIG.DB_NAME,
-  port: CONFIG.DB_PORT,
+	connectionString: `${process.env.DB_URL}`
 });
 
 /*


### PR DESCRIPTION
Adds a Dockerfile based upon nodejs to run website and planned tasks.  
It doesn't include a postgresql server that could be run from official image as to prevent any lag in maintenance.

See readme and develop for more information on how to build and run it.

Don't merge it directly, remains to be tested:
* Cron tasks (with and without imposm)
* Install/init