### PR TITLE
Ajout d'un check de prérequis en amont du script d'update projet

### DIFF
--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -182,6 +182,18 @@ var script = `#!/bin/bash
 
 set -e
 
+echo "== Prerequisites"
+nbProjects=$(${PSQL} -tAc "select count(*) from pdm_projects" | sed 's/[^0-9]*//g' )
+nbPoints=$(${PSQL} -tAc "select count(*) from pdm_projects_points" | sed 's/[^0-9]*//g' )
+
+if [[ $nbProjects < 1 ]]; then
+  echo "WARN: No known projects in SQL projects table"
+fi
+if [[ $nbPoints < 1 ]]; then
+  echo "WARN: No declared points for projects contributions"
+fi
+${separator}
+
 echo "== Create work directory"
 mkdir -p "${CONFIG.WORK_DIR}"
 ${separator}


### PR DESCRIPTION
J'ai l'honneur de vous soumettre la merge request suivante.

En cherchant pourquoi je n'avais plus de décompte de contribution et de mise à jour de mon podium sur Enedis, je me suis rendu compte que mes tables pdm_projects et pdm_projects_points étaient vides. Ceci empêchant l'INSERT des contributions de la journée lors de l'update.

J'ai donc rajouté un petit check pour que le problème sorte dans les logs chaque jour :)