### PR TITLE
Fix Dockerfile missing bc package for projects updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN groupadd --gid 10001 -r osm \
     && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get -y --no-install-recommends install postgresql-client-13 libpq-dev libgeos-dev osmium-tool python3 python3-requests \
+    && apt-get -y --no-install-recommends install postgresql-client-13 libpq-dev libgeos-dev osmium-tool python3 python3-requests bc \
     && apt-get clean \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Petit fix de dernière minute suite à une exécution complète du script d'update.

Le package bc est nécessaire pour faire les dénombrements
J'ai exécuté un recalcul complet à la suite de ça pour vérifier la bonne exécution