### PR TITLE
Ajout des couches osm-extra dans l'éditeur intégré

### DIFF
--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -149,8 +149,8 @@ Plusieurs sources de tuiles sont mobilisables, et sont à faire apparaître dans
 * `name` : nom à faire apparaître à l'utilisateur
 * `subtitles` (optionnel) : objet clé > valeur pour remplacer les sous-titres des signalements Osmose (recherche par motif)
 * `buttons` : libellé à faire apparaître sur les boutons d'édition (exemple `{ "done": "C'est fait", "false": "Rien ici" }`)
-* `minZoom` (défaut 7): Niveau de zoom minimum au delà duquel la couche est visible
-* `maxZoom` (défaut 18): Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `minzoom` (défaut 7): Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 18): Niveau de zoom maximal au delà duquel la couche n'est plus visible
 * `tiles` (défaut) : Liste d'URL TMS
 
 #### Notes OSM
@@ -171,8 +171,8 @@ Les objets actuellement présents dans OpenStreetMap peuvent être affichés pou
 * `source` (obligatoire `osm`): type de source
 * `name` : nom à faire apparaître à l'utilisateur
 * `description` : texte descriptif de l'objet affiché
-* `minZoom` (défaut 7) : Niveau de zoom minimum au delà duquel la couche est visible
-* `maxZoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `minzoom` (défaut 7) : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 * `tiles` (défaut) : Liste d'URL TMS
 * `layers` (défaut) : Liste des layers correspondant à `tiles` à utiliser
 
@@ -182,15 +182,29 @@ Cette source ne peut apparaître qu'une seule fois, et correspond aux objets rec
 
 Des objets indirectement liés au projet mais pertinents pour la contribution peuvent également apparaître. Les propriétés à renseigner sont les suivantes :
 
-* `source` (obligatoire `osm-compare`): type de source
+* `source` (obligatoire `osm-compare`) : type de source
 * `name` : nom à faire apparaître à l'utilisateur
 * `description` : texte descriptif de l'objet affiché
-* `minZoom` (défaut 9) : Niveau de zoom minimum au delà duquel la couche est visible
-* `maxZoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `minzoom` (défaut 9) : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 * `tiles` (défaut) : Liste d'URL TMS
 * `layers` (défaut) : Liste des layers correspondant à `tiles` à utiliser
 
 Cette source ne peut apparaître qu'une seule fois, et correspond aux objets recherchés dans les options `database.compare` de `info.json`.
+
+#### OpenStreetMap extra objects
+
+Ces couches affichent des objets non pris en compte dans le périmètre du projet. Ils sont affichés pour informer les contributeurs que quelque chose de différent existe déjà à cet endroit. Les propriétés à fournir sont les suivantes :
+
+* `source` (obligatoire `osm-extra`) : type de source
+* `name` : nom à faire apparaître à l'utilisateur
+* `description` : texte descriptif de l'objet affiché
+* `minzoom` (défaut 9) : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `tiles` (défaut) : Liste d'URL TMS
+* `layers` (défaut) : Liste des layers correspondant à `tiles` à utiliser
+
+Ces sources peuvent apparaitre autant de fois que nécessaire
 
 #### Fonds raster
 
@@ -201,8 +215,8 @@ Des couches raster peuvent être ajoutées en fond de carte pour faciliter la co
 * `name` : nom à faire apparaître à l'utilisateur
 * `tiles` : Tableau d'URL TMS
 * `attribution` : Attribution à faire apparaitre sur la carte
-* `minZoom` (défaut 2) : Niveau de zoom minimum au delà duquel la couche est visible
-* `maxZoom` (défaut 19) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `minzoom` (défaut 2) : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 19) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 * `tileSize` (défaut 256) : Taille d'une arrête de tuile en pixels
 
 Ces sources doivent être déclarées dans l'ordre inverse d'apparition. La couche inférieure doit être donnée en premier.
@@ -212,8 +226,8 @@ Ces sources doivent être déclarées dans l'ordre inverse d'apparition. La couc
 Pour activer l'affichage de statistiques selon le découpage administratif, vous pouvez ajouter la couche ayant la définition suivante :
 
 * `source` (obligatoire `stats`): type de source
-* `minZoom` (défaut 2) : Niveau de zoom minimum au delà duquel la couche est visible
-* `maxZoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
+* `minzoom` (défaut 2) : Niveau de zoom minimum au delà duquel la couche est visible
+* `maxzoom` (défaut 14) : Niveau de zoom maximal au delà duquel la couche n'est plus visible
 * `tiles` (défaut) : Tableau d'URL TMS
 * `layers` (défaut) : Liste des layers correspondant à `tiles` à utiliser
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -149,8 +149,8 @@ Several data sources can be used, and are to be displayed in the `datasources` f
 * `name`: name to be displayed to the user
 * `subtitles` (optional): key object > value to replace the subtitles of Osmose reports (search by pattern)
 * `buttons`: label to be displayed on the edit buttons (example `{ "done": "It's done", "false": "Nothing here" }`)
-* `minZoom` (default 7): minimum zoom level for making this layer visible
-* `maxZoom` (default 18): maximum zoom level for making this layer visible
+* `minzoom` (default 7): minimum zoom level for making this layer visible
+* `maxzoom` (default 18): maximum zoom level for making this layer visible
 * `tiles` (default): TMS URL list
 
 #### OSM Notes
@@ -171,8 +171,8 @@ Objects currently present in OpenStreetMap can be displayed to avoid duplicates 
 * `source` (mandatory `osm`): source type
 * `name`: name to be displayed to the user
 * `description`: descriptive text of the displayed object
-* `minZoom` (default 7): minimum zoom level for making this layer visible
-* `maxZoom` (default 14): maximum zoom level for making this layer visible
+* `minzoom` (default 7): minimum zoom level for making this layer visible
+* `maxzoom` (default 14): maximum zoom level for making this layer visible
 * `tiles` (default): TMS URL list
 * `layers` (default): Layer names list to use and corresponding to `tiles` indices
 
@@ -182,15 +182,29 @@ This source can appear only once, and corresponds to the objects searched for in
 
 Objects indirectly related to the project but relevant to the contribution may also appear. The properties to be filled in are the following:
 
-* `source` (mandatory `osm-compare`): type of source, mandatory value `osm-compare`
+* `source` (mandatory `osm-compare`): type of source
 * `name`: name to be displayed to the user
 * `description`: descriptive text of the displayed object
-* `minZoom` (default 9): minimum zoom level for making this layer visible
-* `maxZoom` (default 14): maximum zoom level for making this layer visible
+* `minzoom` (default 9): minimum zoom level for making this layer visible
+* `maxzoom` (default 14): maximum zoom level for making this layer visible
 * `tiles` (default): TMS URL list
 * `layers` (default): Layer names list to use and corresponding to `tiles` indices
 
 This source can only appear once, and corresponds to the objects searched for in the `database.compare` options of `info.json`.
+
+#### OpenStreetMap extra objects
+
+Objects outside the project's scope, displayed as to inform contributors that something different already exists in place. The properties to be filled in are the following:
+
+* `source` (mandatory `osm-extra`): type of source
+* `name`: name to be displayed to the user
+* `description`: descriptive text of the displayed object
+* `minzoom` (default 9): minimum zoom level for making this layer visible
+* `maxzoom` (default 14): maximum zoom level for making this layer visible
+* `tiles` (default): TMS URL list
+* `layers` (default): Layer names list to use and corresponding to `tiles` indices
+
+This source can appear as many time as required
 
 #### Background imagery
 
@@ -201,8 +215,8 @@ Raster tile imagery can be added in background to make contribution easier or gi
 * `name`: name shown to users
 * `tiles` (default): list of TMS URL
 * `attribution`: attribution to display on map
-* `minZoom` (default 2): minimum zoom level for making this layer visible
-* `maxZoom` (default 19): maximum zoom level for making this layer visible
+* `minzoom` (default 2): minimum zoom level for making this layer visible
+* `maxzoom` (default 19): maximum zoom level for making this layer visible
 * `tileSize` (default 256): width and length of a tile in pixels
 
 These sources should be declared in reverse order of display. The lower layer should be declared first.
@@ -212,8 +226,8 @@ These sources should be declared in reverse order of display. The lower layer sh
 Another kind of datasource can be added and refers to geographical statistics, over administrative boundaries for instance
 
 * `source` (mandatory `stats`): statistics source type
-* `minZoom` (default 2): minimum zoom level for making this layer visible
-* `maxZoom` (default 14): maximum zoom level for making this layer visible
+* `minzoom` (default 2): minimum zoom level for making this layer visible
+* `maxzoom` (default 14): maximum zoom level for making this layer visible
 * `tiles` (default): list of TMS URL
 * `layers` (default): Layer names list to use and corresponding to `tiles` indices
 

--- a/website/templates/components/map.pug
+++ b/website/templates/components/map.pug
@@ -54,7 +54,7 @@ script.
 				}
 				else {
 					filter = ["==", ["get", "osm_id"], id];
-					layers = listOfSources.filter(ps => ps.startsWith("osm_") || ps.startsWith("osm-compare_"));
+					layers = listOfSources.filter(ps => ps.startsWith("osm_") || ps.startsWith("osm-compare_") || ps.startsWith("osm-extra_"));
 				}
 			}
 

--- a/website/templates/components/map_sidebar_feature.pug
+++ b/website/templates/components/map_sidebar_feature.pug
@@ -491,7 +491,7 @@ script.
 			});
 		}
 		// OSM comparison features
-		else if(s.startsWith("osm-compare_")) {
+		else if(s.startsWith("osm-compare_") || s.startsWith("osm-extra_")) {
 			const tags = typeof p.tags === "string" ? JSON.parse(p.tags) : p.tags;
 			const osmSource = osmCompareSources[parseInt(feature.source.split("_")[1])];
 
@@ -503,12 +503,14 @@ script.
 			getReadableTags(resDiv, tags, "Attributs");
 			createFeatureButton(resDiv, "add", "btn-block mt-2 dropup", { originalCoordinates });
 
-			const divButtonFalse = document.createElement("button");
-			divButtonFalse.classList.add("btn", "btn-warning", "btn-block", "mt-2");
-			divButtonFalse.appendChild(document.createTextNode("✘ #{__("Rien ici / déjà fait")}"));
-			divButtonFalse.title = "Marquer qu'il n'y a rien ici si vous n'avez pas vu de #{statistics.feature_name} sur le terrain";
-			divButtonFalse.addEventListener("click", e => ignoreOsmCompare(feature));
-			resDiv.appendChild(divButtonFalse);
+			if (s.startsWith("osm-compare_")){
+				const divButtonFalse = document.createElement("button");
+				divButtonFalse.classList.add("btn", "btn-warning", "btn-block", "mt-2");
+				divButtonFalse.appendChild(document.createTextNode("✘ #{__("Rien ici / déjà fait")}"));
+				divButtonFalse.title = "Marquer qu'il n'y a rien ici si vous n'avez pas vu de #{statistics.feature_name} sur le terrain";
+				divButtonFalse.addEventListener("click", e => ignoreOsmCompare(feature));
+				resDiv.appendChild(divButtonFalse);
+			}
 		}
 		// Mapillary pictures
 		else if(s.startsWith("background_") && p.sequence_id && p.id) {

--- a/website/utils.js
+++ b/website/utils.js
@@ -116,7 +116,7 @@ exports.getMapStyle = (p) => {
 				const id = `${ds.source}_${dsid}`;
 
 				sources[id] = Object.assign({
-					minzoo: 2,
+					minzoom: 2,
 					maxzoom: 19,
 					tileSize: 256
 				}, filterDatasource(ds));
@@ -160,6 +160,38 @@ exports.getMapStyle = (p) => {
 				}
 			});
 
+			// Source osm-extra
+			p.datasources
+			.filter(ds => "osm-extra" === ds.source)
+			.forEach((ds, dsid) => {
+				const id = `${ds.source}_${dsid}`;
+				const color = ds.color;
+				const layer = ds.layer;
+
+				sources[id] = Object.assign({
+					tiles: [ `${CONFIG.PDM_TILES_URL}/${layer}/{z}/{x}/{y}.mvt` ],
+					layers: [ layer ],
+					minzoom: 9,
+					maxzoom: 14
+				}, filterDatasource(ds));
+				sources[id].type = "vector";
+				updateVectorMinZoom(sources[id].minzoom);
+
+				layers.push({
+					id: id,
+					source: id,
+					type: "circle",
+					"source-layer": sources[id].layers[0],
+					paint: {
+						"circle-color": color,
+						"circle-opacity": [ "interpolate", ["linear"], ["zoom"], 9, 0, 10, 1 ],
+						"circle-radius": [ "interpolate", ["linear"], ["zoom"], 9, 2, 11, 3, 13, 5, 19, 12 ]
+					}
+				});
+
+				legend.push({ media: "vector", color, label: ds.name, layerId: id });
+			});
+
 			// Source OSM Compare
 			p.datasources
 			.filter(ds => "osm-compare" === ds.source)
@@ -175,7 +207,7 @@ exports.getMapStyle = (p) => {
 					maxzoom: 14
 				}, filterDatasource(ds));
 				sources[id].type = "vector";
-				updateVectorMinZoom(sources[id].minZoom);
+				updateVectorMinZoom(sources[id].minzoom);
 
 				layers.push({
 					id: id,
@@ -207,7 +239,7 @@ exports.getMapStyle = (p) => {
 					maxzoom: 14
 				}, filterDatasource(ds));
 				sources[id].type = "vector";
-				updateVectorMinZoom(sources[id].minZoom);
+				updateVectorMinZoom(sources[id].minzoom);
 
 				layers.push({
 					id: id,
@@ -235,7 +267,7 @@ exports.getMapStyle = (p) => {
 					maxzoom: 18
 				}, filterDatasource(ds));
 				sources[id].type = "vector";
-				updateVectorMinZoom(sources[id].minZoom);
+				updateVectorMinZoom(sources[id].minzoom);
 
 				layers.push({
 					id: id,


### PR DESCRIPTION
Suite à #228, je propose une capacité simple d'ajouter autant de sources que nécessaire avec le type `osm-extra`.
Les objets incomplets passeront par Osmose directement (il faut que je fasse la PR pour ajouter le bon analyzer).

Le style est le même que `osm-compare`, on peut uniquement changer la couleur dans le fichier info.json.

A voir en live ici : https://enedis.openstreetmap.fr/projects/2021-01_poteaux/map#map=11.58/45.991/6.0846&sidebar=

J'utilise un jeu de tuiles comportant deux layers, il y a donc la meme URL dans les deux couches, seul le nom du layer change.
Si nécessaire il aurait été possible d'utiliser deux pyramides indépendantes.

Il reste un léger "bug" : lorsqu'on clic sur un point d'une couche osm-extra, la sidebar n'affiche pas les attributs du point, bien que les deux layers de mes tuiles disposent bien des mêmes attributs.
Peut-être as-tu une explication @PanierAvide ?