### PR TITLE
Fix variable indéfinie features_update

### DIFF
--- a/db/20_features_update.js
+++ b/db/20_features_update.js
@@ -217,7 +217,7 @@ if [ "$mode" == "init" ]; then
 
 	echo "Post SQL..."
 	${postSQLFull}
-	psql -d ${PSQL_DB} -f "${__dirname}/22_features_post_init.sql"
+	psql -d ${process.env.DB_URL} -f "${__dirname}/22_features_post_init.sql"
 else
 	echo "Post Update SQL..."
 	${postUpdateSQLFull}

--- a/db/22_features_post_init.sql
+++ b/db/22_features_post_init.sql
@@ -23,7 +23,7 @@ stats AS (
 	FROM pdm_feature_counts_per_boundary
 	GROUP BY project, boundary
 )
-SELECT s.project, s.boundary, b.name, b.admin_level, s.stats, maxc.amount - minc.amount AS nb, b.centre AS geom
+SELECT s.project, s.boundary, b.id, b.name, b.admin_level, s.stats, maxc.amount - minc.amount AS nb, b.centre AS geom
 FROM stats s
 JOIN minc ON minc.project = s.project AND minc.boundary = s.boundary
 JOIN maxc ON maxc.project = s.project AND maxc.boundary = s.boundary

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -31,6 +31,12 @@ case $command in
     npm run features:update
     ./db/21_features_update_tmp.sh
     ;;
+"uninstall")
+    npm run features:update
+    
+    psql -d $DB_URL -f ./db/91_project_uninstall_tmp.sql
+    psql -d $DB_URL -f ./db/90_uninstall.sql
+    ;;
 *)
     echo "Command $command unknown"
     exit 2


### PR DESCRIPTION
Il y avait un petit bug dans le script de feature_update, la variable `PSQL_DB` était encore utilisée au lieu de l'env `DB_URL`.

J'ai retiré l'execution de project_update dans la commande init, inutile et ajouté une commande d'uninstall dans le docker-entrypoint.