### PR TITLE
Stats for long projects

### DIFF
--- a/db/10_project_update.js
+++ b/db/10_project_update.js
@@ -249,18 +249,18 @@ ${separator}
 `;
 }
 
-const projectsToProcess = runForAll ? Object.values(projects) : projectsFold.current;
-projectsToProcess.forEach(project => {
+Object.values(projects).forEach(project => {
 	let oshInput = OSH_UPDATED;
 	const oshProject = OSH_FILTERED.replace("filtered", `${project.id.split("_").pop()}`);
 	const oshFiltered = OSH_FILTERED.replace("filtered", `${project.id.split("_").pop()}.filtered`);
 	const oshUsefull = OSH_USEFULL.replace("usefull", `${project.id.split("_").pop()}.usefull`);
+	const days = getProjectDays(project);
 
 	let tagFilterParts = project.database.osmium_tag_filter.split("&");
 
 	script += `
-cur_timestamp=$(date -Idate --utc ${new Date(project.end_date+"T23:59:59Z").getTime() < Date.now() ? `-d ${project.end_date}` : ""})
-cnt_timestamp=${new Date(project.end_date+"T23:59:59Z").getTime() < Date.now() ? `$(date -Idate --utc -d ${project.start_date})` : `""`}
+cur_timestamp=$(date -Idate --utc)
+cnt_timestamp=$(date -Idate --utc -d ${project.start_date})
 prj_timestamp=$(date -Idate --utc -d ${project.start_date})
 if [[ -z \$cnt_timestamp && -n "\$prev_timestamp" ]]; then
 	cnt_timestamp=$(date -Idate --utc -d \$prev_timestamp)
@@ -330,12 +330,7 @@ if ${HAS_BOUNDARY}; then
 fi
 
 echo "Counting from \$cnt_timestamp"
-days=""
-local_timestamp=$cnt_timestamp
-until [[ ! "\$local_timestamp" < "\$cur_timestamp" ]]; do
-	days="\$days \$local_timestamp"
-	local_timestamp=$(date -Idate --utc -d "\$local_timestamp + 1 day" )
-done
+days="${days.join(" ")}"
 days=($\{days##*( )\})
 for day in "\${days[@]}"; do
 	echo "Processing $day"

--- a/db/12_projects_contribs.sql
+++ b/db/12_projects_contribs.sql
@@ -2,13 +2,13 @@
 INSERT INTO pdm_user_names
 SELECT DISTINCT ON (userid) userid, username
 FROM pdm_changes
-WHERE userid IS NOT NULL AND project=:project_id AND ts BETWEEN :start_date AND :end_date
+WHERE userid IS NOT NULL AND project=:project_id AND ts >= :start_date
 ORDER BY userid, ts DESC
 ON CONFLICT (userid)
 DO UPDATE SET username = EXCLUDED.username;
 
 -- Establishing user contributions in every running project
-DELETE FROM pdm_user_contribs WHERE project=:project_id AND ts BETWEEN :start_date AND :end_date;
+DELETE FROM pdm_user_contribs WHERE project=:project_id AND ts >= :start_date;
 
 WITH projectChanges AS (
 	SELECT c.project, c.userid, c.ts, c.contrib AS contribution, pp.points
@@ -16,7 +16,7 @@ WITH projectChanges AS (
 	JOIN pdm_projects p ON p.project=c.project
 	JOIN pdm_projects_points pp ON pp.project=c.project AND c.contrib=pp.contrib
 
-	WHERE c.project=:project_id AND c.ts BETWEEN :start_date AND :end_date
+	WHERE c.project=:project_id AND c.ts >= :start_date
 )
 INSERT INTO pdm_user_contribs(project, userid, ts, contribution, points)
 SELECT * FROM projectChanges;

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -15,25 +15,25 @@ case $command in
     psql -d $DB_URL -f ./db/00_init.sql
     ;;
 "init")
-    npm run project:update
+    npm run project:update $otherArgs
     ./db/09_project_update_tmp.sh $otherArgs
-    npm run features:update
+    npm run features:update $otherArgs
     ./db/21_features_update_tmp.sh init
     ;;
 "run")
-    npm run project:update
+    npm run project:update $otherArgs
     npm run start
     ;;
 "update_project")
-    npm run project:update
+    npm run project:update $otherArgs
     ./db/09_project_update_tmp.sh $otherArgs
     ;;
 "update_features")
-    npm run features:update
+    npm run features:update $otherArgs
     ./db/21_features_update_tmp.sh $otherArgs
     ;;
 "uninstall")
-    npm run features:update
+    npm run features:update $otherArgs
 
     psql -d $DB_URL -f ./db/91_project_uninstall_tmp.sql
     psql -d $DB_URL -f ./db/90_uninstall.sql

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -144,5 +144,12 @@
 	"Veuillez réessayer un peu plus tard, merci pour votre compréhension.": "Veuillez réessayer un peu plus tard, merci pour votre compréhension.",
 	"D'autres projets": "D'autres projets",
 	"Plus d'infos sur ce champ": "Plus d'infos sur ce champ",
-	"Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap.": "Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap."
+	"Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap.": "Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap.",
+	"Catalyseur d'énergies pour OpenStreetMap v%s": "Catalyseur d'énergies pour OpenStreetMap v%s",
+	"A propos": "A propos",
+	"Les projets": "Les projets",
+	"À propos": "À propos",
+	"En ce moment : %s projets prioritaires": "En ce moment : %s projets prioritaires",
+	"Tous nos projets": "Tous nos projets",
+	"Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.": "Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données."
 }

--- a/website/templates/components/stats.pug
+++ b/website/templates/components/stats.pug
@@ -76,13 +76,6 @@ script.
 			};
 
 			// Blocks for small stats
-			if(new Date("#{end_date}T23:59:59Z").getTime() >= Date.now()) {
-				addBlock(Math.round((new Date("#{end_date}T23:59:59Z").getTime() - Date.now()) / (1000*3600*24)), "#{__("jours restants")}");
-			}
-			else {
-				addBlock(Math.round((new Date("#{end_date}T23:59:59Z").getTime() - new Date("#{start_date}T00:00:00Z").getTime()) / (1000*3600*24)), "#{__("jours de contributions")}");
-			}
-
 			if(res.added) { addBlock(numberFormat.format(res.added), "#{title.toLowerCase()} ajoutés"); }
 			if(res.count) { addBlock(numberFormat.format(res.count), "#{title.toLowerCase()} au total dans OSM"); }
 			if(res.tasksSolved !== undefined) { addBlock(numberFormat.format(res.tasksSolved), "#{statistics.osmose_tasks}"); }

--- a/website/templates/pages/multi_projects.pug
+++ b/website/templates/pages/multi_projects.pug
@@ -3,39 +3,40 @@ extends ../layout.pug
 
 block navbar
 	a(href="#others")
-		i.fa.fa-file-download(title=__("Autres projets"))
-		span= __("Autres projets")
+		i.fa.fa-file-download(title=__("Les projets"))
+		span= __("Les projets")
 	a(href="/about")
-		i.fa.fa-flag(title=__("A propos"))
-		span= __("A propos")
+		i.fa.fa-flag(title=__("À propos"))
+		span= __("À propos")
 
 
 block content
-	div.container
-		//- Project summary
-		div#summary.jumbotron.py-2.px-3.pb-3.p-md-5.mb-3.text-white.rounded.bg-dark.position-relative
-			img.position-absolute.pdm-project-badge(src=icon alt="" width="100")
-			div.col-8.px-0.pb-1
-				h1.font-italic= __("En ce moment : %s projets en cours", currentProjects.length)
+	if currentProjects.length > 0
+		div.container.pb-5
+			//- Project summary
+			div#summary.jumbotron.py-2.px-3.pb-3.p-md-5.mb-3.text-white.rounded.bg-dark.position-relative
+				img.position-absolute.pdm-project-badge(src=icon alt="" width="100")
+				div.col-8.px-0.pb-1
+					h1.font-italic= __("En ce moment : %s projets prioritaires", currentProjects.length)
 
-			div.row
-				each proj in currentProjects
-					div.col-md-6.col-lg-4.h-100
-						div.media.my-1.p-2(style="background-color: white; border-radius: 10px")
-							a.align-self-center.mr-3(href=`/projects/${proj.id}`)
-								img(src=proj.icon alt="" style="height: 100px")
-							div.media-body.align-self-center
-								a.text-decoration-none(href=`/projects/${proj.id}`)= proj.title
+				div.row
+					each proj in currentProjects
+						div.col-md-6.col-lg-4.h-100
+							div.media.my-1.p-2(style="background-color: white; border-radius: 10px")
+								a.align-self-center.mr-3(href=`/projects/${proj.id}`)
+									img(src=proj.icon alt="" style="height: 100px")
+								div.media-body.align-self-center
+									a.text-decoration-none(href=`/projects/${proj.id}`)= proj.title
 
 	//- Other projects
 	a#others
-	div.container-fluid.py-5
+	div.container-fluid.pb-5
 		div.container.blog-post
 			h2.blog-post-title
 				i.fa.fa-file-download.mr-2(style="font-size: 2.1rem")
-				| #{__("Autres projets")}
+				| #{__("Tous nos projets")}
 
-			p= __("Retrouvez d'autres projets du mois, leurs outils, statistiques et données.")
+			p= __("Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.")
 				div.row.align-items-center
 					each proj in otherProjects
 						div.col-md-6.col-lg-4.h-100

--- a/website/utils.js
+++ b/website/utils.js
@@ -436,11 +436,13 @@ exports.getOsmToUrlMappings = () => {
 exports.getProjectDays = (project) => {
 	const days = [];
 	const start = new Date(project.start_date);
-	let end = new Date(project.end_date);
-	if(end.getTime() > Date.now()) { end = new Date(); }
+	let end = new Date();
+	const summarize = end.getTime() - start.getTime() > 1000*60*60*24*60;
 
 	for(let dt = new Date(start); dt.getTime() <= end.getTime(); dt.setTime(dt.getTime() + 1000*60*60*24)) {
-		days.push(new Date(dt).toISOString().split("T")[0]);
+		if(!summarize || end.getTime() - dt.getTime() < 1000*60*60*24 || new Date(dt).toISOString().split("T")[0].substring(8,10) === "01") {
+			days.push(new Date(dt).toISOString().split("T")[0]);
+		}
 	}
 
 	return days;


### PR DESCRIPTION
@flacombe Une petite PR sur laquelle j'aimerais avoir ton avis avant intégration :

- J'ai fait sauter les contraintes dans les stats liées à la date de fin d'un projet. Peu importe celle-ci, les stats sont générées depuis la date de lancement jusqu'à la date du jour.
- La date de fin du projet ne sert qu'à le mettre en avant sur la page d'accueil (noté "projets prioritaires"). Le nombre de jours restants d'un projet n'apparaît donc plus dans les stats.
- Si un projet a été commencé depuis plus de 2 mois, la génération des stats se fait en ne prenant que le premier jour de chaque mois + date du jour. Exemple : un projet lancé en août 2022 ira chercher les infos aux dates : 2022-08-01, 2022-09-01, 2022-10-01, 2022-10-12.

Tout ça améliore l'affichage des graphiques et accélère la génération de stats. Comme ça va avoir pas mal d'impacts sur le rendu de l'instance Enedis, je préfère vérifier avec toi qu'il n'y a pas d'effets de bords :wink: 