### PR TITLE
feat: add zoom override for background sources

### DIFF
--- a/website/utils.js
+++ b/website/utils.js
@@ -116,8 +116,8 @@ exports.getMapStyle = (p) => {
 				const id = `${ds.source}_${dsid}`;
 
 				sources[id] = Object.assign({
-					minzoom: 2,
-					maxzoom: 19,
+					minzoom: sources[id]?.minzoom ? sources[id].minzoom : 2,
+					maxzoom: sources[id]?.maxzoom ? sources[id].maxzoom : 19,
 					tileSize: 256
 				}, filterDatasource(ds));
 
@@ -148,7 +148,6 @@ exports.getMapStyle = (p) => {
 				}
 				else {
 					sources[id].type = "raster";
-
 					layers.push({
 						id: id,
 						source: id,

--- a/website/utils.js
+++ b/website/utils.js
@@ -118,7 +118,7 @@ exports.getMapStyle = (p) => {
 				sources[id] = Object.assign({
 					minzoom: sources[id]?.minzoom ? sources[id].minzoom : 2,
 					maxzoom: sources[id]?.maxzoom ? sources[id].maxzoom : 19,
-					tileSize: 256
+					tileSize: sources[id]?.tileSize ? sources[id].tileSize : 256
 				}, filterDatasource(ds));
 
 				if(ds.tiles === "mapillary") {

--- a/website/utils.js
+++ b/website/utils.js
@@ -115,11 +115,7 @@ exports.getMapStyle = (p) => {
 			.forEach((ds, dsid) => {
 				const id = `${ds.source}_${dsid}`;
 
-				sources[id] = Object.assign({
-					minzoom: sources[id]?.minzoom ? sources[id].minzoom : 2,
-					maxzoom: sources[id]?.maxzoom ? sources[id].maxzoom : 19,
-					tileSize: sources[id]?.tileSize ? sources[id].tileSize : 256
-				}, filterDatasource(ds));
+				sources[id] = Object.assign({}, filterDatasource(ds));
 
 				if(ds.tiles === "mapillary") {
 					sources[id].tiles = [ "https://tiles.mapillary.com/maps/vtp/mly1_computed_public/2/{z}/{x}/{y}?access_token="+CONFIG.MAPILLARY_API_KEY ];
@@ -148,6 +144,22 @@ exports.getMapStyle = (p) => {
 				}
 				else {
 					sources[id].type = "raster";
+
+					// Default minzoom values if not specified
+					if (!sources[id].minzoom) {
+						sources[id].minzoom = 2
+					}
+
+					// Default maxzoom values if not specified
+					if (!sources[id].maxzoom) {
+						sources[id].maxzoom = 19
+					}
+
+					// Default tileSize values if not specified
+					if (!sources[id].tileSize) {
+						sources[id].tileSize = 256
+					}
+
 					layers.push({
 						id: id,
 						source: id,


### PR DESCRIPTION
As I was trying to add a link with wms tiles I was blocked on level 19.
Documentation for Background imagery list vars minzoom and maxzoom but where not implemented. 