### PR TITLE
Improve projects update timestamp, fixes 

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -7,15 +7,17 @@ CREATE TABLE pdm_user_names(
 
 -- Projects
 CREATE TABLE pdm_projects(
-	project VARCHAR NOT NULL,
+	project VARCHAR PRIMARY KEY,
 	start_date TIMESTAMP NOT NULL,
-	end_date TIMESTAMP NULL
+	end_date TIMESTAMP NULL,
+	lastupdate_date TIMESTAMP NULL
 );
 
 CREATE TABLE pdm_projects_points (
-	project VARCHAR NOT NULL,
-	contrib VARCHAR NOT NULL,
-	points integer not null
+	project VARCHAR,
+	contrib VARCHAR,
+	points integer not null,
+	PRIMARY KEY (project, contrib)
 );
 
 -- User contributions through all projects


### PR DESCRIPTION
I found several bugs in the project update process (yes, again).
* Scripts splitting in #295 doesn't allow to use osh_timestamp any more to get project last update time since os file is updated prior to run projects_update_tmp.sh
* No primary keys were defined in pdm_projects and prm_projects_points tables
* User contrib were not inserted as time window was osh current time to osh current time
* Async truncate and insert queries to install projects in pdm_project table were inefficient as truncate was executed pretty always after the insert.

Then I propose the following changes:
* Create primary keys in pdm_projects and pdm_projects_points and stop truncating every day
* Create a lastupdate_date column in pdm_projects to store each project last update date, which could be different from osh timestamp
* Current update timestamp is now took from OSH timestamp (and not current time)
* Project update time window is now defined as [last_update, osh_timestamp]

It is intended to make the update process more reliable and less vulnerable to delays in source data updates.

Migrating the database requires the following queries to be executed once:
```sql
alter table pdm_projects add primary key(project);
alter table pdm_projects_points add primary key (project, contrib);
alter table pdm_projects add column lastupdate_date timestamp null;
```
Optionally populate the `lastupdate_date` column as to not process all project stats again.