### PR TITLE
osm now use only oauth2

### DIFF
--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -48,7 +48,7 @@ La configuration générale de l'outil est à renseigner dans `config.json`. Un 
 - `DB_USE_IMPOSM_UPDATE` : Active ou désactive l'intégration d'imposm3 (permet d'utiliser une base existante et tenue à jour par d'autres moyens, par défaut `true`)
 - `WORK_DIR` : dossier de téléchargement et stockage temporaire (doit pouvoir contenir le fichier OSH PBF, exemple `/tmp/pdm`)
 - `OSM_URL` : instance OpenStreetMap à utiliser (exemple `https://www.openstreetmap.org`)
-- `API_OSM_URL` : instance API OpenStreetMap à utiliser (exemple `https://api.openstreetmap.org`)
+- `OSM_API_URL` : instance API OpenStreetMap à utiliser (exemple `https://api.openstreetmap.org`)
 - `JOSM_REMOTE_URL` : adresse du serveur JOSM à contacter (exemple `http://localhost:8111`)
 - `OSMOSE_URL` : instance Osmose à utiliser (exemple `https://osmose.openstreetmap.fr`)
 - `NOMINATIM_URL` : instance de Nominatim à utiliser (exemple `https://nominatim.openstreetmap.org`)

--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -43,12 +43,12 @@ La configuration générale de l'outil est à renseigner dans `config.json`. Un 
 
 - `OSM_USER` : nom d'utilisateur OpenStreetMap pour la récupération de l'historique des modifications avec métadonnées
 - `OSM_PASS` : mot de passe associé au compte utilisateur OSM
-- `OSM_API_KEY` : clé d'API OSM
-- `OSM_API_SECRET` : secret lié à la clé d'API OSM
+- `OSM_CLIENT_ID` : client ID généré depuis le compte OpenStreetMap
 - `OSH_PBF_URL` : URL du fichier OSH.PBF (historique et métadonnées, exemple `https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf`)
 - `DB_USE_IMPOSM_UPDATE` : Active ou désactive l'intégration d'imposm3 (permet d'utiliser une base existante et tenue à jour par d'autres moyens, par défaut `true`)
 - `WORK_DIR` : dossier de téléchargement et stockage temporaire (doit pouvoir contenir le fichier OSH PBF, exemple `/tmp/pdm`)
 - `OSM_URL` : instance OpenStreetMap à utiliser (exemple `https://www.openstreetmap.org`)
+- `API_OSM_URL` : instance API OpenStreetMap à utiliser (exemple `https://api.openstreetmap.org`)
 - `JOSM_REMOTE_URL` : adresse du serveur JOSM à contacter (exemple `http://localhost:8111`)
 - `OSMOSE_URL` : instance Osmose à utiliser (exemple `https://osmose.openstreetmap.fr`)
 - `NOMINATIM_URL` : instance de Nominatim à utiliser (exemple `https://nominatim.openstreetmap.org`)

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -48,7 +48,7 @@ The general configuration of the tool is to be filled in `config.json`. There is
 - `DB_USE_IMPOSM_UPDATE` : enable or disabled Imposm3 integration (to use an existing database which would be maintained by other means, by default `true`)
 - `WORK_DIR`: download and temporary storage folder (must have capacity to store the OSH PBF file, example `/tmp/pdm`)
 - `OSM_URL`: OpenStreetMap instance to use (example `https://www.openstreetmap.org`)
-- `API_OSM_URL` : API OpenStreetMap instance to use (example `https://www.api.openstreetmap.org`)
+- `OSM_API_URL` : API OpenStreetMap instance to use (example `https://www.api.openstreetmap.org`)
 - `JOSM_REMOTE_URL`: address of the JOSM server to reach (example `http://localhost:8111`)
 - `OSMOSE_URL`: Osmose instance to use (example `https://osmose.openstreetmap.fr`)
 - `NOMINATIM_URL`: instance of Nominatim to use (example `https://nominatim.openstreetmap.org`)

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -43,12 +43,12 @@ The general configuration of the tool is to be filled in `config.json`. There is
 
 - `OSM_USER`: OpenStreetMap username for retrieving the modification history with metadata
 - `OSM_PASS`: password associated with the OSM user account
-- `OSM_API_KEY`: OSM API key
-- `OSM_API_SECRET`: secret linked to the OSM API key
+- `OSM_CLIENT_ID` : client ID généré depuis le compte OpenStreetMap
 - `OSH_PBF_URL`: URL of the OSH.PBF file (history and metadata, example `https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf`)
 - `DB_USE_IMPOSM_UPDATE` : enable or disabled Imposm3 integration (to use an existing database which would be maintained by other means, by default `true`)
 - `WORK_DIR`: download and temporary storage folder (must have capacity to store the OSH PBF file, example `/tmp/pdm`)
 - `OSM_URL`: OpenStreetMap instance to use (example `https://www.openstreetmap.org`)
+- `API_OSM_URL` : API OpenStreetMap instance to use (example `https://www.api.openstreetmap.org`)
 - `JOSM_REMOTE_URL`: address of the JOSM server to reach (example `http://localhost:8111`)
 - `OSMOSE_URL`: Osmose instance to use (example `https://osmose.openstreetmap.fr`)
 - `NOMINATIM_URL`: instance of Nominatim to use (example `https://nominatim.openstreetmap.org`)

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,6 @@
 {
   "OSM_URL": "https://www.openstreetmap.org",
-  "API_OSM_URL": "https://api.openstreetmap.org",
+  "OSM_API_URL": "https://api.openstreetmap.org",
   "OSM_USER": "user",
   "OSM_PASS": "pass",
   "OSM_CLIENT_ID": "id",

--- a/config.example.json
+++ b/config.example.json
@@ -1,24 +1,32 @@
 {
-	"OSM_URL": "https://www.openstreetmap.org",
-	"OSM_USER": "user",
-	"OSM_PASS": "pass",
-	"OSM_API_KEY": "key",
-	"OSM_API_SECRET": "secret",
-	"OSMOSE_URL": "https://osmose.openstreetmap.fr",
-	"NOMINATIM_URL": "https://nominatim.openstreetmap.org",
-	"MAPILLARY_URL": "https://www.mapillary.com",
-	"MAPILLARY_API_KEY": "yourtoken",
-	"MATOMO_HOST": "https://stats.domaine.fr/",
-	"MATOMO_SITE": "6",
-	"REPOSITORY_URL": "https://github.com/vdct/ProjetDuMois",
-	"JOSM_REMOTE_URL": "http://localhost:8111",
-	"OSH_PBF_URL": "https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf",
-	"MAPBOX_STYLE": "https://tile-vect.openstreetmap.fr/styles/liberty/style.json",
-	"PDM_TILES_URL": "http://localhost:7800",
-	"DB_USE_IMPOSM_UPDATE": true,
-	"WORK_DIR": "/tmp/pdm",
-	"GEOJSON_BOUNDS": {
-		"type": "Polygon",
-		"coordinates": [ [ [ 55.02777, -21.55017 ], [ 56.08795, -21.55017 ], [ 56.08795, -20.73556 ], [ 55.02777, -20.73556 ], [ 55.02777, -21.55017 ] ] ]
-	}
+  "OSM_URL": "https://www.openstreetmap.org",
+  "API_OSM_URL": "https://api.openstreetmap.org",
+  "OSM_USER": "user",
+  "OSM_PASS": "pass",
+  "OSM_CLIENT_ID": "id",
+  "OSMOSE_URL": "https://osmose.openstreetmap.fr",
+  "NOMINATIM_URL": "https://nominatim.openstreetmap.org",
+  "MAPILLARY_URL": "https://www.mapillary.com",
+  "MAPILLARY_API_KEY": "yourtoken",
+  "MATOMO_HOST": "https://stats.domaine.fr/",
+  "MATOMO_SITE": "6",
+  "REPOSITORY_URL": "https://github.com/vdct/ProjetDuMois",
+  "JOSM_REMOTE_URL": "http://localhost:8111",
+  "OSH_PBF_URL": "https://osm-internal.download.geofabrik.de/europe/france/reunion-internal.osh.pbf",
+  "MAPBOX_STYLE": "https://tile-vect.openstreetmap.fr/styles/liberty/style.json",
+  "PDM_TILES_URL": "http://localhost:7800",
+  "DB_USE_IMPOSM_UPDATE": true,
+  "WORK_DIR": "/tmp/pdm",
+  "GEOJSON_BOUNDS": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [55.02777, -21.55017],
+        [56.08795, -21.55017],
+        [56.08795, -20.73556],
+        [55.02777, -20.73556],
+        [55.02777, -21.55017]
+      ]
+    ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "projetdumoisfr",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "projetdumoisfr",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.14.0",
@@ -25,8 +25,8 @@
         "mapillary-js": "^4.0.0",
         "marked": "^1.1.0",
         "node-fetch": "^2.6.7",
-        "osm-auth": "^1.0.2",
-        "osm-request": "^1.2.10",
+        "osm-auth": "^2.5.0",
+        "osm-request": "^2.0.0",
         "pg": "^8.5.1",
         "pic4carto": "^2.1.12",
         "pug": "^3.0.1",
@@ -1005,11 +1005,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/crypto-browserify": {
@@ -1819,17 +1820,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jshashes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.8.tgz",
-      "integrity": "sha512-btmQZ/w1rj8Lb6nEwvhjM7nBYoj54yaEFo2PWh3RkxZ8qNwuvOxvQYN/JxVuwoMmdIluL+XwYVJ+pEEZoSYybQ==",
-      "bin": {
-        "hashes": "bin/hashes"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/json-stable-stringify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
@@ -2336,9 +2326,10 @@
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2360,15 +2351,6 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ohauth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ohauth/-/ohauth-1.0.0.tgz",
-      "integrity": "sha1-wui/877wrkkUR5IiQ+G6cFEX3ks=",
-      "dependencies": {
-        "jshashes": "~1.0.0",
-        "xtend": "~4.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -2406,39 +2388,24 @@
       "dev": true
     },
     "node_modules/osm-auth": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-1.0.2.tgz",
-      "integrity": "sha1-Waq3/vGq+DyBPOaAKPxlCmECc0I=",
-      "dependencies": {
-        "ohauth": "~1.0.0",
-        "resolve-url": "~0.2.1",
-        "store": "~2.0.4",
-        "xtend": "~4.0.0"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-2.5.0.tgz",
+      "integrity": "sha512-w3NnYbt+0PIih2Kwr1sLfQWehdLbcA3gZNJhX4VOBfeRtvm30iZA3nURphuZDokZ8Kmdv4LWB+AiIng2b+KvIA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.18"
       }
     },
     "node_modules/osm-request": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/osm-request/-/osm-request-1.2.10.tgz",
-      "integrity": "sha512-E9XgqOOdBUVzmyXi30ykvUg5vPK2yX8Y2uJnAGc6/6PLeVPSFb6BcUG/v/HOtJVZIxbwFExTI/IpFP+OTpuNLg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/osm-request/-/osm-request-2.0.0.tgz",
+      "integrity": "sha512-WCxfbvVgbPKiMtLoPRmH2qbCHxH53RhFVJoSxTflzxvgUTloP9KOFnOCGrip+INuxi6ErmnSK11atndY8iyj5Q==",
+      "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.0.5",
-        "osm-auth": "^1.1.0",
-        "xml2js": "^0.4.23",
+        "cross-fetch": "^4.0.0",
+        "osm-auth": "^2.5.0",
+        "xml2js": "^0.6.2",
         "xmlserializer": "^0.6.1"
-      }
-    },
-    "node_modules/osm-request/node_modules/osm-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-1.1.0.tgz",
-      "integrity": "sha512-e/ecarlh2N/FMfiNa/ZChUIZN8q1LqK4F0iPV4g1MmfHi3/VJ+STJ0qE7ALL3OgHR5IQc3JuI63SCDqHNGt4ew==",
-      "dependencies": {
-        "ohauth": "~1.0.0",
-        "resolve-url": "~0.2.1",
-        "store": "~2.0.4",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/packet-reader": {
@@ -3020,12 +2987,6 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
-    },
     "node_modules/ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -3076,9 +3037,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/send": {
       "version": "0.17.1",
@@ -3223,14 +3185,6 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/store": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
-      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/stream-browserify": {
@@ -3713,9 +3667,10 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -3728,6 +3683,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -4628,11 +4584,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "crypto-browserify": {
@@ -5322,11 +5278,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jshashes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.8.tgz",
-      "integrity": "sha512-btmQZ/w1rj8Lb6nEwvhjM7nBYoj54yaEFo2PWh3RkxZ8qNwuvOxvQYN/JxVuwoMmdIluL+XwYVJ+pEEZoSYybQ=="
-    },
     "json-stable-stringify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
@@ -5760,9 +5711,9 @@
       "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -5771,15 +5722,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "ohauth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ohauth/-/ohauth-1.0.0.tgz",
-      "integrity": "sha1-wui/877wrkkUR5IiQ+G6cFEX3ks=",
-      "requires": {
-        "jshashes": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -5810,38 +5752,19 @@
       "dev": true
     },
     "osm-auth": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-1.0.2.tgz",
-      "integrity": "sha1-Waq3/vGq+DyBPOaAKPxlCmECc0I=",
-      "requires": {
-        "ohauth": "~1.0.0",
-        "resolve-url": "~0.2.1",
-        "store": "~2.0.4",
-        "xtend": "~4.0.0"
-      }
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-2.5.0.tgz",
+      "integrity": "sha512-w3NnYbt+0PIih2Kwr1sLfQWehdLbcA3gZNJhX4VOBfeRtvm30iZA3nURphuZDokZ8Kmdv4LWB+AiIng2b+KvIA=="
     },
     "osm-request": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/osm-request/-/osm-request-1.2.10.tgz",
-      "integrity": "sha512-E9XgqOOdBUVzmyXi30ykvUg5vPK2yX8Y2uJnAGc6/6PLeVPSFb6BcUG/v/HOtJVZIxbwFExTI/IpFP+OTpuNLg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/osm-request/-/osm-request-2.0.0.tgz",
+      "integrity": "sha512-WCxfbvVgbPKiMtLoPRmH2qbCHxH53RhFVJoSxTflzxvgUTloP9KOFnOCGrip+INuxi6ErmnSK11atndY8iyj5Q==",
       "requires": {
-        "cross-fetch": "^3.0.5",
-        "osm-auth": "^1.1.0",
-        "xml2js": "^0.4.23",
+        "cross-fetch": "^4.0.0",
+        "osm-auth": "^2.5.0",
+        "xml2js": "^0.6.2",
         "xmlserializer": "^0.6.1"
-      },
-      "dependencies": {
-        "osm-auth": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/osm-auth/-/osm-auth-1.1.0.tgz",
-          "integrity": "sha512-e/ecarlh2N/FMfiNa/ZChUIZN8q1LqK4F0iPV4g1MmfHi3/VJ+STJ0qE7ALL3OgHR5IQc3JuI63SCDqHNGt4ew==",
-          "requires": {
-            "ohauth": "~1.0.0",
-            "resolve-url": "~0.2.1",
-            "store": "~2.0.4",
-            "xtend": "~4.0.0"
-          }
-        }
       }
     },
     "packet-reader": {
@@ -6350,11 +6273,6 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -6402,9 +6320,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "send": {
       "version": "0.17.1",
@@ -6523,11 +6441,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "store": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
-      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -6976,9 +6889,9 @@
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "projetdumoisfr",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projetdumoisfr",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "ProjetDuMois.fr est un tableau de bord pour encourager les contributions aux Projets du mois d'OpenStreetMap en France.",
   "main": "website/index.js",
   "scripts": {
@@ -38,8 +38,8 @@
     "mapillary-js": "^4.0.0",
     "marked": "^1.1.0",
     "node-fetch": "^2.6.7",
-    "osm-auth": "^1.0.2",
-    "osm-request": "^1.2.10",
+    "osm-auth": "^2.5.0",
+    "osm-request": "^2.0.0",
     "pg": "^8.5.1",
     "pic4carto": "^2.1.12",
     "pug": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projetdumoisfr",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "description": "ProjetDuMois.fr est un tableau de bord pour encourager les contributions aux Projets du mois d'OpenStreetMap en France.",
   "main": "website/index.js",
   "scripts": {

--- a/website/index.js
+++ b/website/index.js
@@ -2,26 +2,34 @@
  * API main code
  */
 
-const express = require('express');
-const cors = require('cors');
-const compression = require('compression');
-const path = require('path');
-const fs = require('fs');
-const fetch = require('node-fetch');
-const projects = require('./projects');
-const CONFFILE = require('../config.json');
-const PCKGE = require('../package.json');
-const { foldProjects, queryParams, getMapStyle, getMapStatsStyle, getBadgesDetails, getOsmToUrlMappings, getProjectDays } = require('./utils');
-const { Pool } = require('pg');
-const { I18n } = require('i18n');
+const express = require("express");
+const cors = require("cors");
+const compression = require("compression");
+const path = require("path");
+const fs = require("fs");
+const fetch = require("node-fetch");
+const projects = require("./projects");
+const CONFFILE = require("../config.json");
+const PCKGE = require("../package.json");
+const {
+  foldProjects,
+  queryParams,
+  getMapStyle,
+  getMapStatsStyle,
+  getBadgesDetails,
+  getOsmToUrlMappings,
+  getProjectDays,
+} = require("./utils");
+const { Pool } = require("pg");
+const { I18n } = require("i18n");
 
-const CONFIG = Object.assign(CONFFILE, {package_version:PCKGE.version});
+const CONFIG = Object.assign(CONFFILE, { package_version: PCKGE.version });
 
 /*
  * Connect to database
  */
 const pool = new Pool({
-	connectionString: `${process.env.DB_URL}`
+  connectionString: `${process.env.DB_URL}`,
 });
 
 /*
@@ -29,13 +37,12 @@ const pool = new Pool({
  */
 
 const i18n = new I18n({
-	locales: ['fr', 'en'],
-	directory: path.join(__dirname, 'locales'),
-	autoReload: true,
-	defaultLocale: 'fr',
-	retryInDefaultLocale: true
+  locales: ["fr", "en"],
+  directory: path.join(__dirname, "locales"),
+  autoReload: true,
+  defaultLocale: "fr",
+  retryInDefaultLocale: true,
 });
-
 
 /*
  * Init API
@@ -44,482 +51,708 @@ const i18n = new I18n({
 const app = express();
 const port = process.env.PORT || 3000;
 app.use(cors());
-app.options('*', cors());
+app.options("*", cors());
 app.use(compression());
 app.use(i18n.init);
-app.use(function(req, res, next) {
-	res.locals.__ = res.__ = function() {
-		return i18n.__.apply(req, arguments);
-	};
-	next();
+app.use(function (req, res, next) {
+  res.locals.__ = res.__ = function () {
+    return i18n.__.apply(req, arguments);
+  };
+  next();
 });
 
-app.set('view engine', 'pug');
-app.set('views', __dirname+'/templates');
+app.set("view engine", "pug");
+app.set("views", __dirname + "/templates");
 
 // Index
-app.get('/', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.status(503).render('pages/maintenance'); }
+app.get("/", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.status(503).render("pages/maintenance");
+  }
 
-	const p = foldProjects(projects);
-	const nbProjects = (p.current ? p.current.length : 0) + (p.next ? p.next.length : 0) + (p.past ? p.past.length : 0);
+  const p = foldProjects(projects);
+  const nbProjects =
+    (p.current ? p.current.length : 0) +
+    (p.next ? p.next.length : 0) +
+    (p.past ? p.past.length : 0);
 
-	// One single project
-	if(nbProjects === 1) {
-		// One currently active project
-		if(p.current && p.current.length === 1) {
-			res.redirect(`/projects/${p.current.pop().id}`);
-		}
-		// One next project
-		else if(p.next && p.next.length > 0) {
-			res.redirect(`/projects/${p.next.pop().id}`);
-		}
-		// One last project
-		else if(p.past && p.past.length > 0) {
-			res.redirect(`/projects/${p.past.pop().id}`);
-		}
-	}
-	// Multiple projects
-	else if(nbProjects > 1) {
-		res.render('pages/multi_projects', Object.assign({ CONFIG, currentProjects: p.current, otherProjects: p.past.reverse() }));
-	}
-	// No projects at all
-	else {
-		res.redirect('/error/500');
-	}
+  // One single project
+  if (nbProjects === 1) {
+    // One currently active project
+    if (p.current && p.current.length === 1) {
+      res.redirect(`/projects/${p.current.pop().id}`);
+    }
+    // One next project
+    else if (p.next && p.next.length > 0) {
+      res.redirect(`/projects/${p.next.pop().id}`);
+    }
+    // One last project
+    else if (p.past && p.past.length > 0) {
+      res.redirect(`/projects/${p.past.pop().id}`);
+    }
+  }
+  // Multiple projects
+  else if (nbProjects > 1) {
+    res.render(
+      "pages/multi_projects",
+      Object.assign({
+        CONFIG,
+        currentProjects: p.current,
+        otherProjects: p.past.reverse(),
+      }),
+    );
+  }
+  // No projects at all
+  else {
+    res.redirect("/error/500");
+  }
 });
 
 // About
-app.get('/about', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.status(503).render('pages/maintenance'); }
+app.get("/about", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.status(503).render("pages/maintenance");
+  }
 
-	res.render('pages/about', Object.assign({ CONFIG }));
+  res.render("pages/about", Object.assign({ CONFIG }));
 });
 
 // HTTP errors
-app.get('/error/:code', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/error/:code", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	const httpcode = req.params.code && !isNaN(req.params.code) ? req.params.code : "400";
-	res.status(httpcode).render('pages/error', { CONFIG, httpcode });
+  const httpcode =
+    req.params.code && !isNaN(req.params.code) ? req.params.code : "400";
+  res.status(httpcode).render("pages/error", { CONFIG, httpcode });
 });
 
 // Project page
-app.get('/projects/:id', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/projects/:id", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	if(!req.params.id || !projects[req.params.id]) {
-		return res.redirect('/error/404');
-	}
+  if (!req.params.id || !projects[req.params.id]) {
+    return res.redirect("/error/404");
+  }
 
-	const p = projects[req.params.id];
-	const all = foldProjects(projects);
-	const toDisplay = all.past.reverse().concat(all.current.filter(p => p.id !== req.params.id));
-	const isActive = all.current.length > 0 && all.current.find(p => p.id === req.params.id) !== undefined;
-	const isNext = all.next && all.next.find(p => p.id === req.params.id) !== undefined;
-	const isRecentPast = all.past && all.past.length > 0 && all.past.find (p => p.id === req.params.id && new Date(p.end_date+"T23:59:59Z").getTime() >= Date.now() - 30*24*60*60*1000) !== undefined;
-	res.render('pages/project', Object.assign({ CONFIG, isActive, isNext, isRecentPast, projects: all, projectsToDisplay: toDisplay, days: getProjectDays(p) }, p));
+  const p = projects[req.params.id];
+  const all = foldProjects(projects);
+  const toDisplay = all.past
+    .reverse()
+    .concat(all.current.filter((p) => p.id !== req.params.id));
+  const isActive =
+    all.current.length > 0 &&
+    all.current.find((p) => p.id === req.params.id) !== undefined;
+  const isNext =
+    all.next && all.next.find((p) => p.id === req.params.id) !== undefined;
+  const isRecentPast =
+    all.past &&
+    all.past.length > 0 &&
+    all.past.find(
+      (p) =>
+        p.id === req.params.id &&
+        new Date(p.end_date + "T23:59:59Z").getTime() >=
+          Date.now() - 30 * 24 * 60 * 60 * 1000,
+    ) !== undefined;
+  res.render(
+    "pages/project",
+    Object.assign(
+      {
+        CONFIG,
+        isActive,
+        isNext,
+        isRecentPast,
+        projects: all,
+        projectsToDisplay: toDisplay,
+        days: getProjectDays(p),
+      },
+      p,
+    ),
+  );
 });
 
 // Project map editor
-app.get('/projects/:id/map', async (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/projects/:id/map", async (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	if(!req.params.id || !projects[req.params.id]) {
-		return res.redirect('/error/404');
-	}
+  if (!req.params.id || !projects[req.params.id]) {
+    return res.redirect("/error/404");
+  }
 
-	const p = projects[req.params.id];
-	const all = foldProjects(projects);
-	const isActive = all.current.length > 0 && all.current.find(p => p.id === req.params.id) !== undefined;
-	const mapstyle = await getMapStyle(p);
-	res.render('pages/map', Object.assign({ CONFIG, isActive, tagToUrl: getOsmToUrlMappings() }, p, mapstyle));
+  const p = projects[req.params.id];
+  const all = foldProjects(projects);
+  const isActive =
+    all.current.length > 0 &&
+    all.current.find((p) => p.id === req.params.id) !== undefined;
+  const mapstyle = await getMapStyle(p);
+  res.render(
+    "pages/map",
+    Object.assign(
+      { CONFIG, isActive, tagToUrl: getOsmToUrlMappings() },
+      p,
+      mapstyle,
+    ),
+  );
 });
 
 // Project notes list
-app.get('/projects/:id/issues', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/projects/:id/issues", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	if(!req.params.id || !projects[req.params.id]) {
-		return res.redirect('/error/404');
-	}
+  if (!req.params.id || !projects[req.params.id]) {
+    return res.redirect("/error/404");
+  }
 
-	const p = projects[req.params.id];
-	const all = foldProjects(projects);
-	const isActive = all.current.length > 0 && all.current.find(p => p.id === req.params.id) !== undefined;
-	res.render('pages/issues', Object.assign({ CONFIG, isActive }, p));
+  const p = projects[req.params.id];
+  const all = foldProjects(projects);
+  const isActive =
+    all.current.length > 0 &&
+    all.current.find((p) => p.id === req.params.id) !== undefined;
+  res.render("pages/issues", Object.assign({ CONFIG, isActive }, p));
 });
 
 // Project statistics
-app.get('/projects/:id/stats', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/projects/:id/stats", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	if(!req.params.id || !projects[req.params.id]) {
-		return res.redirect('/error/404');
-	}
+  if (!req.params.id || !projects[req.params.id]) {
+    return res.redirect("/error/404");
+  }
 
-	const p = projects[req.params.id];
-	const allPromises = [];
-	const osmUserAuthentified = typeof req.query.osm_user === "string" && req.query.osm_user.trim().length > 0;
-	const daysToKeep = (day) => {
-		if(Date.now() - (new Date(p.start_date)).getTime() < 1000*60*60*24*60) { return true; }
-		else if(Date.now() - (new Date(day)).getTime() < 1000*60*60*24) { return true; }
-		else { return day.substring(8, 10) == "01"; }
-	};
+  const p = projects[req.params.id];
+  const allPromises = [];
+  const osmUserAuthentified =
+    typeof req.query.osm_user === "string" &&
+    req.query.osm_user.trim().length > 0;
+  const daysToKeep = (day) => {
+    if (
+      Date.now() - new Date(p.start_date).getTime() <
+      1000 * 60 * 60 * 24 * 60
+    ) {
+      return true;
+    } else if (Date.now() - new Date(day).getTime() < 1000 * 60 * 60 * 24) {
+      return true;
+    } else {
+      return day.substring(8, 10) == "01";
+    }
+  };
 
-	// Fetch Osmose statistics
-	allPromises.push(Promise.all(p.datasources
-	.filter(ds => ds.source === "osmose")
-	.map(ds => {
-		const params = { item: ds.item, class: ds.class, start_date: p.start_date, country: ds.country };
-		return fetch(`${CONFIG.OSMOSE_URL}/fr/issues/graph.json?${queryParams(params)}`)
-		.then(res => res.json())
-		.then(res => ({
-			label: ds.name,
-			data: Object.entries(res.data)
-				.filter(e => daysToKeep(e[0]))
-				.map(e => ({ t: e[0], y: e[1] }))
-				.sort((a,b) => a.t.localeCompare(b.t)),
-			fill: false,
-			borderColor: ds.color || "#c62828",
-			lineTension: 0
-		}));
-	}))
-	.then(results => {
-		if(!results || results.length === 0 || results.filter(r => r.data && r.data.length > 0).length === 0) { return {}; }
+  // Fetch Osmose statistics
+  allPromises.push(
+    Promise.all(
+      p.datasources
+        .filter((ds) => ds.source === "osmose")
+        .map((ds) => {
+          const params = {
+            item: ds.item,
+            class: ds.class,
+            start_date: p.start_date,
+            country: ds.country,
+          };
+          return fetch(
+            `${CONFIG.OSMOSE_URL}/fr/issues/graph.json?${queryParams(params)}`,
+          )
+            .then((res) => res.json())
+            .then((res) => ({
+              label: ds.name,
+              data: Object.entries(res.data)
+                .filter((e) => daysToKeep(e[0]))
+                .map((e) => ({ t: e[0], y: e[1] }))
+                .sort((a, b) => a.t.localeCompare(b.t)),
+              fill: false,
+              borderColor: ds.color || "#c62828",
+              lineTension: 0,
+            }));
+        }),
+    ).then((results) => {
+      if (
+        !results ||
+        results.length === 0 ||
+        results.filter((r) => r.data && r.data.length > 0).length === 0
+      ) {
+        return {};
+      }
 
-		const nbTasksStart = results.map(r => r.data[0].y).reduce((acc,cur) => acc + cur);
-		const nbTasksEnd = results.map(r => r.data[r.data.length-1].y).reduce((acc,cur) => acc + cur);
+      const nbTasksStart = results
+        .map((r) => r.data[0].y)
+        .reduce((acc, cur) => acc + cur);
+      const nbTasksEnd = results
+        .map((r) => r.data[r.data.length - 1].y)
+        .reduce((acc, cur) => acc + cur);
 
-		return {
-			chart: results,
-			tasksSolved: nbTasksStart - nbTasksEnd > 0 ? nbTasksStart - nbTasksEnd : undefined
-		};
-	}));
+      return {
+        chart: results,
+        tasksSolved:
+          nbTasksStart - nbTasksEnd > 0 ? nbTasksStart - nbTasksEnd : undefined,
+      };
+    }),
+  );
 
-	// Fetch notes counts
-	if(p.datasources.find(ds => ds.source === "notes")) {
-		allPromises.push(pool.query(`
+  // Fetch notes counts
+  if (p.datasources.find((ds) => ds.source === "notes")) {
+    allPromises.push(
+      pool
+        .query(
+          `
 			SELECT ts, open, closed
 			FROM pdm_note_counts
 			WHERE project = $1
 			ORDER BY ts ASC
-		`, [req.params.id])
-		.then(results => ({
-			chartNotes: results.rows.length > 0 ? [
-				{
-					label: "Ouvertes",
-					data: results.rows.map(r => ({ t: r.ts, y: r.open })),
-					fill: false,
-					borderColor: "#c62828",
-					lineTension: 0
-				},
-				{
-					label: "Résolues",
-					data: results.rows.map(r => ({ t: r.ts, y: r.closed })),
-					fill: false,
-					borderColor: "#388E3C",
-					lineTension: 0
-				}
-   			] : null,
-			statClosedNotes: results.rows.length > 0 ?
-				(results.rows[results.rows.length-1].closed > results.rows[results.rows.length-1].open ?
-					results.rows[results.rows.length-1].closed
-					: (results.rows[results.rows.length-1].closed / results.rows[results.rows.length-1].open * 100).toFixed(0)+'%')
-				: '0',
-			openedNotes: results.rows.length > 0 && results.rows[results.rows.length-1].open
-		})));
-	}
+		`,
+          [req.params.id],
+        )
+        .then((results) => ({
+          chartNotes:
+            results.rows.length > 0
+              ? [
+                  {
+                    label: "Ouvertes",
+                    data: results.rows.map((r) => ({ t: r.ts, y: r.open })),
+                    fill: false,
+                    borderColor: "#c62828",
+                    lineTension: 0,
+                  },
+                  {
+                    label: "Résolues",
+                    data: results.rows.map((r) => ({ t: r.ts, y: r.closed })),
+                    fill: false,
+                    borderColor: "#388E3C",
+                    lineTension: 0,
+                  },
+                ]
+              : null,
+          statClosedNotes:
+            results.rows.length > 0
+              ? results.rows[results.rows.length - 1].closed >
+                results.rows[results.rows.length - 1].open
+                ? results.rows[results.rows.length - 1].closed
+                : (
+                    (results.rows[results.rows.length - 1].closed /
+                      results.rows[results.rows.length - 1].open) *
+                    100
+                  ).toFixed(0) + "%"
+              : "0",
+          openedNotes:
+            results.rows.length > 0 &&
+            results.rows[results.rows.length - 1].open,
+        })),
+    );
+  }
 
-	// Fetch feature counts
-	if(p.statistics.count) {
-		allPromises.push(pool.query(`
+  // Fetch feature counts
+  if (p.statistics.count) {
+    allPromises.push(
+      pool
+        .query(
+          `
 			SELECT ts, amount
 			FROM pdm_feature_counts
 			WHERE project = $1
 			ORDER BY ts ASC
-		`, [req.params.id])
-		.then(results => ({
-			chart: [{
-				label: "Nombre dans OSM",
-				data: results.rows.map(r => ({ t: r.ts, y: r.amount })),
-				fill: false,
-				borderColor: "#388E3C",
-				lineTension: 0
-			}],
-			added: results.rows.length > 0 && results.rows[results.rows.length-1].amount - results.rows[0].amount
-		})));
+		`,
+          [req.params.id],
+        )
+        .then((results) => ({
+          chart: [
+            {
+              label: "Nombre dans OSM",
+              data: results.rows.map((r) => ({ t: r.ts, y: r.amount })),
+              fill: false,
+              borderColor: "#388E3C",
+              lineTension: 0,
+            },
+          ],
+          added:
+            results.rows.length > 0 &&
+            results.rows[results.rows.length - 1].amount -
+              results.rows[0].amount,
+        })),
+    );
 
-		allPromises.push(pool.query(
-			`SELECT COUNT(*) AS amount FROM pdm_project_${req.params.id.split("_").pop()}`
-		).then(results => ({
-			count: results.rows.length > 0 && results.rows[0].amount
-		})));
+    allPromises.push(
+      pool
+        .query(
+          `SELECT COUNT(*) AS amount FROM pdm_project_${req.params.id.split("_").pop()}`,
+        )
+        .then((results) => ({
+          count: results.rows.length > 0 && results.rows[0].amount,
+        })),
+    );
 
-		if(p.datasources.find(ds => ds.source === "stats")) {
-			allPromises.push(pool.query(
-				`SELECT admin_level, max(nb) AS amount FROM pdm_boundary_tiles WHERE project = $1 GROUP BY admin_level`,
-				[ req.params.id ]
-			).then(results => {
-				const maxLevel = {};
-				results.rows.forEach(r => {
-					if(!isNaN(parseInt(r.amount))) { maxLevel[r.admin_level] = r.amount; }
-				});
-				return Object.keys(maxLevel).length > 0 ? getMapStatsStyle(p, maxLevel) : null;
-			})
-			.then(mapStyle => ({ mapStyle })));
-		}
-	}
+    if (p.datasources.find((ds) => ds.source === "stats")) {
+      allPromises.push(
+        pool
+          .query(
+            `SELECT admin_level, max(nb) AS amount FROM pdm_boundary_tiles WHERE project = $1 GROUP BY admin_level`,
+            [req.params.id],
+          )
+          .then((results) => {
+            const maxLevel = {};
+            results.rows.forEach((r) => {
+              if (!isNaN(parseInt(r.amount))) {
+                maxLevel[r.admin_level] = r.amount;
+              }
+            });
+            return Object.keys(maxLevel).length > 0
+              ? getMapStatsStyle(p, maxLevel)
+              : null;
+          })
+          .then((mapStyle) => ({ mapStyle })),
+      );
+    }
+  }
 
-	// Fetch user statistics from DB
-	allPromises.push(pool.query(`SELECT * FROM pdm_leaderboard WHERE project = $1 ORDER BY pos`, [req.params.id])
-	.then(results => ({
-		nbContributors: results.rows.length,
-		leaderboard: osmUserAuthentified ? results.rows : null
-	})));
+  // Fetch user statistics from DB
+  allPromises.push(
+    pool
+      .query(`SELECT * FROM pdm_leaderboard WHERE project = $1 ORDER BY pos`, [
+        req.params.id,
+      ])
+      .then((results) => ({
+        nbContributors: results.rows.length,
+        leaderboard: osmUserAuthentified ? results.rows : null,
+      })),
+  );
 
-	// Fetch tags statistics
-	allPromises.push(pool.query(`
+  // Fetch tags statistics
+  allPromises.push(
+    pool
+      .query(
+        `
 		SELECT k, COUNT(*) AS amount
 		FROM (
 			SELECT json_object_keys(tags) AS k
 			FROM pdm_project_${req.params.id.split("_").pop()}
 		) a
 		GROUP BY k
-		ORDER BY COUNT(*) desc;`
-	)
-	.then(results => {
-		const d = results.rows.filter(r => r.amount >= (results.rows[0].amount / 10));
-		return {
-			chartKeys: {
-				labels: d.map(r => r.k),
-				datasets: [{
-					label: "Nombre d'objets pour la clé",
-					data: d.map(r => r.amount),
-					fill: false,
-					backgroundColor: "#1E88E5",
-				}]
-			}
-		};
-	}));
+		ORDER BY COUNT(*) desc;`,
+      )
+      .then((results) => {
+        const d = results.rows.filter(
+          (r) => r.amount >= results.rows[0].amount / 10,
+        );
+        return {
+          chartKeys: {
+            labels: d.map((r) => r.k),
+            datasets: [
+              {
+                label: "Nombre d'objets pour la clé",
+                data: d.map((r) => r.amount),
+                fill: false,
+                backgroundColor: "#1E88E5",
+              },
+            ],
+          },
+        };
+      }),
+  );
 
-	Promise.allSettled(allPromises)
-	.then(results => {
-		let toSend = {};
-		if (typeof results == "object" && results != null){
-			results.forEach(r => {
-				if (r != null && r.status === "fulfilled"){
-					Object.entries(r.value).forEach(e => {
-						if(!toSend[e[0]]) { toSend[e[0]] = e[1]; }
-						else if(e[0] === "chart") { toSend.chart = toSend.chart.concat(e[1]); }
-					});
-				}
-			});
-		}
-		res.send(toSend);
-	});
+  Promise.allSettled(allPromises).then((results) => {
+    let toSend = {};
+    if (typeof results == "object" && results != null) {
+      results.forEach((r) => {
+        if (r != null && r.status === "fulfilled") {
+          Object.entries(r.value).forEach((e) => {
+            if (!toSend[e[0]]) {
+              toSend[e[0]] = e[1];
+            } else if (e[0] === "chart") {
+              toSend.chart = toSend.chart.concat(e[1]);
+            }
+          });
+        }
+      });
+    }
+    res.send(toSend);
+  });
 });
 
 // User contributions
-app.post('/projects/:id/contribute/:userid', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.post("/projects/:id/contribute/:userid", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	// Check project is active
-	const p = foldProjects(projects);
-	if(!req.params.id || !projects[req.params.id] || p.current.length < 1 || p.current.find (p => p.id === req.params.id) === undefined) {
-		return res.redirect('/error/400');
-	}
+  // Check project is active
+  const p = foldProjects(projects);
+  if (
+    !req.params.id ||
+    !projects[req.params.id] ||
+    p.current.length < 1 ||
+    p.current.find((p) => p.id === req.params.id) === undefined
+  ) {
+    return res.redirect("/error/400");
+  }
 
-	// Check userid seem valid
-	if(!req.params.userid || !/^\d+$/.test(req.params.userid) || typeof req.query.username !== "string" || req.query.username.trim().length === 0) {
-		return res.redirect('/error/400');
-	}
+  // Check userid seem valid
+  if (
+    !req.params.userid ||
+    !/^\d+$/.test(req.params.userid) ||
+    typeof req.query.username !== "string" ||
+    req.query.username.trim().length === 0
+  ) {
+    return res.redirect("/error/400");
+  }
 
-	// Check type of contribution
-	if(!req.query.type || !["add", "edit", "delete", "note"].includes(req.query.type)) {
-		return res.redirect('/error/400');
-	}
+  // Check type of contribution
+  if (
+    !req.query.type ||
+    !["add", "edit", "delete", "note"].includes(req.query.type)
+  ) {
+    return res.redirect("/error/400");
+  }
 
-	// Update user name in DB
-	pool.query('INSERT INTO pdm_user_names(userid, username) VALUES ($1, $2) ON CONFLICT (userid) DO UPDATE SET username = EXCLUDED.username', [req.params.userid, req.query.username])
-	.then(r1 => {
-		// Get badges before edit
-		pool.query('SELECT * FROM pdm_get_badges($1, $2)', [req.params.id, req.params.userid])
-		.then(r2 => {
-			const badgesBefore = r2.rows;
+  // Update user name in DB
+  pool
+    .query(
+      "INSERT INTO pdm_user_names(userid, username) VALUES ($1, $2) ON CONFLICT (userid) DO UPDATE SET username = EXCLUDED.username",
+      [req.params.userid, req.query.username],
+    )
+    .then((r1) => {
+      // Get badges before edit
+      pool
+        .query("SELECT * FROM pdm_get_badges($1, $2)", [
+          req.params.id,
+          req.params.userid,
+        ])
+        .then((r2) => {
+          const badgesBefore = r2.rows;
 
-			// Insert contribution (will be deleted and re-inserted at next project update)
-			pool.query('WITH points AS (SELECT pts FROM pdm_projects_points WHERE project=$1 AND contrib=$3) INSERT INTO pdm_user_contribs(project, userid, ts, contribution, verified, points) VALUES (SELECT $1, $2, current_timestamp, $3, false, pts FROM points)', [req.params.id, req.params.userid, req.query.type])
-			.then(r3 => {
-				// Get badges after contribution
-				pool.query('SELECT * FROM pdm_get_badges($1, $2)', [req.params.id, req.params.userid])
-				.then(r4 => {
-					const badgesAfter = r4.rows;
-					const badgesForDisplay = badgesAfter.filter(b => {
-						const badgeInBefore = badgesBefore.find(b2 => b.id === b2.id);
-						return !badgeInBefore || !b.acquired || badgeInBefore.acquired !== b.acquired;
-					});
-					res.send({ badges: badgesForDisplay });
-				})
-				.catch(e => {
-					res.redirect('/error/500');
-				});
-			})
-			.catch(e => {
-				res.redirect('/error/500');
-			});
-		})
-		.catch(e => {
-			res.redirect('/error/500');
-		});
-	})
-	.catch(e => {
-		res.redirect('/error/500');
-	});
+          // Insert contribution (will be deleted and re-inserted at next project update)
+          pool
+            .query(
+              "WITH points AS (SELECT pts FROM pdm_projects_points WHERE project=$1 AND contrib=$3) INSERT INTO pdm_user_contribs(project, userid, ts, contribution, verified, points) VALUES (SELECT $1, $2, current_timestamp, $3, false, pts FROM points)",
+              [req.params.id, req.params.userid, req.query.type],
+            )
+            .then((r3) => {
+              // Get badges after contribution
+              pool
+                .query("SELECT * FROM pdm_get_badges($1, $2)", [
+                  req.params.id,
+                  req.params.userid,
+                ])
+                .then((r4) => {
+                  const badgesAfter = r4.rows;
+                  const badgesForDisplay = badgesAfter.filter((b) => {
+                    const badgeInBefore = badgesBefore.find(
+                      (b2) => b.id === b2.id,
+                    );
+                    return (
+                      !badgeInBefore ||
+                      !b.acquired ||
+                      badgeInBefore.acquired !== b.acquired
+                    );
+                  });
+                  res.send({ badges: badgesForDisplay });
+                })
+                .catch((e) => {
+                  res.redirect("/error/500");
+                });
+            })
+            .catch((e) => {
+              res.redirect("/error/500");
+            });
+        })
+        .catch((e) => {
+          res.redirect("/error/500");
+        });
+    })
+    .catch((e) => {
+      res.redirect("/error/500");
+    });
 });
 
 // Add OSM feature to compare exclusion list
-app.post('/projects/:id/ignore/:osmtype/:osmid', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.post("/projects/:id/ignore/:osmtype/:osmid", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	// Check project exists
-	if(!req.params.id || !projects[req.params.id]) {
-		return res.redirect('/error/404');
-	}
-	// Check OSM ID
-	if(!req.params.osmtype || !["node", "way", "relation"].includes(req.params.osmtype) || !req.params.osmid || !/^\d+$/.test(req.params.osmid)) {
-		return res.redirect('/error/400');
-	}
+  // Check project exists
+  if (!req.params.id || !projects[req.params.id]) {
+    return res.redirect("/error/404");
+  }
+  // Check OSM ID
+  if (
+    !req.params.osmtype ||
+    !["node", "way", "relation"].includes(req.params.osmtype) ||
+    !req.params.osmid ||
+    !/^\d+$/.test(req.params.osmid)
+  ) {
+    return res.redirect("/error/400");
+  }
 
-	pool.query('INSERT INTO pdm_compare_exclusions(project, osm_id, userid) VALUES ($1, $2, $3) ON CONFLICT (project, osm_id) DO UPDATE SET ts = current_timestamp, userid = $3', [req.params.id, req.params.osmtype+"/"+req.params.osmid, req.query.user_id])
-	.then(() => {
-		res.send();
-	})
-	.catch(e => {
-		res.redirect('/error/500');
-	});
+  pool
+    .query(
+      "INSERT INTO pdm_compare_exclusions(project, osm_id, userid) VALUES ($1, $2, $3) ON CONFLICT (project, osm_id) DO UPDATE SET ts = current_timestamp, userid = $3",
+      [
+        req.params.id,
+        req.params.osmtype + "/" + req.params.osmid,
+        req.query.user_id,
+      ],
+    )
+    .then(() => {
+      res.send();
+    })
+    .catch((e) => {
+      res.redirect("/error/500");
+    });
 });
 
 // User page
-app.get('/users/:name', (req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
+app.get("/users/:name", (req, res) => {
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
 
-	if(!req.params.name) {
-		return res.redirect('/error/404');
-	}
+  if (!req.params.name) {
+    return res.redirect("/error/404");
+  }
 
-	// Find user in database
-	pool.query(`SELECT userid FROM pdm_user_names WHERE username = $1`, [ req.params.name ])
-	.then(res1 => {
-		if(res1.rows.length === 1) {
-			const userid = res1.rows[0].userid;
+  // Find user in database
+  pool
+    .query(`SELECT userid FROM pdm_user_names WHERE username = $1`, [
+      req.params.name,
+    ])
+    .then((res1) => {
+      if (res1.rows.length === 1) {
+        const userid = res1.rows[0].userid;
 
-			// Fetch badges
-			const sql = Object.entries(projects)
-				.map(e => `SELECT '${e[0]}' AS project, * FROM pdm_get_badges('${e[0]}', $1)`)
-				.concat([`SELECT 'meta' AS project, * FROM pdm_get_badges('meta', $1)`])
-				.join(" UNION ALL ");
+        // Fetch badges
+        const sql = Object.entries(projects)
+          .map(
+            (e) =>
+              `SELECT '${e[0]}' AS project, * FROM pdm_get_badges('${e[0]}', $1)`,
+          )
+          .concat([
+            `SELECT 'meta' AS project, * FROM pdm_get_badges('meta', $1)`,
+          ])
+          .join(" UNION ALL ");
 
-			pool.query(sql, [ userid ])
-			.then(res2 => {
-				res.render('pages/user', { CONFIG, username: req.params.name, userid, badges: getBadgesDetails(projects, res2.rows) });
-			})
-			.catch(e => {
-				res.redirect('/error/500');
-			});
-		}
-		else {
-			res.redirect('/error/404');
-		}
-	})
-	.catch(e => {
-		res.redirect('/error/500');
-	});
+        pool
+          .query(sql, [userid])
+          .then((res2) => {
+            res.render("pages/user", {
+              CONFIG,
+              username: req.params.name,
+              userid,
+              badges: getBadgesDetails(projects, res2.rows),
+            });
+          })
+          .catch((e) => {
+            res.redirect("/error/500");
+          });
+      } else {
+        res.redirect("/error/404");
+      }
+    })
+    .catch((e) => {
+      res.redirect("/error/500");
+    });
 });
 
 // Documentation
-['README.md', 'DEVELOP.md', 'LICENSE.txt'].forEach(file => {
-	app.get(`/${file}`, (req, res) => {
-		res.sendFile(path.join(__dirname, '..', file));
-	});
+["README.md", "DEVELOP.md", "LICENSE.txt"].forEach((file) => {
+  app.get(`/${file}`, (req, res) => {
+    res.sendFile(path.join(__dirname, "..", file));
+  });
 });
 
 // Images
-app.use('/images', express.static(__dirname+'/images'));
-app.use('/website/images', express.static(__dirname+'/images'));
+app.use("/images", express.static(__dirname + "/images"));
+app.use("/website/images", express.static(__dirname + "/images"));
 
 // Static content
-fs.readdirSync(path.join(__dirname, 'static')).forEach(file => {
-	app.get(`/${file}`, (req, res) => {
-		if(file === "manifest.webmanifest") { res.contentType("application/manifest+json"); }
-		res.sendFile(path.join(__dirname, 'static', file));
-	});
+fs.readdirSync(path.join(__dirname, "static")).forEach((file) => {
+  app.get(`/${file}`, (req, res) => {
+    if (file === "manifest.webmanifest") {
+      res.contentType("application/manifest+json");
+    }
+    res.sendFile(path.join(__dirname, "static", file));
+  });
 });
-
 
 // Libraries
 const authorized = {
-	"bootstrap": { "bootstrap.css": "dist/css/bootstrap.min.css" },
-	"bootstrap.native": { "bootstrap.js": "dist/bootstrap-native.min.js" },
-	"chart.js": {
-		"chart.js": "dist/Chart.bundle.min.js",
-		"chart.css": "dist/Chart.min.css"
-	},
-	"mapbox-gl": {
-		"mapbox-gl.js": "dist/mapbox-gl.js",
-		"mapbox-gl.css": "dist/mapbox-gl.css"
-	},
-	"mapillary-js": {
-		"mapillary.js": "dist/mapillary.js",
-		"mapillary.css": "dist/mapillary.css"
-	},
-	"osm-auth": { "osmauth.js": "osmauth.min.js" },
-	"osm-request": { "osmrequest.js": "dist/OsmRequest.js" },
-	"pic4carto": { "pic4carto.js": "dist/P4C.min.js" },
-	"swiped-events": { "swiped-events.js": "dist/swiped-events.min.js" },
-	"wordcloud": { "wordcloud.js": "src/wordcloud2.js" }
+  bootstrap: { "bootstrap.css": "dist/css/bootstrap.min.css" },
+  "bootstrap.native": { "bootstrap.js": "dist/bootstrap-native.min.js" },
+  "chart.js": {
+    "chart.js": "dist/Chart.bundle.min.js",
+    "chart.css": "dist/Chart.min.css",
+  },
+  "mapbox-gl": {
+    "mapbox-gl.js": "dist/mapbox-gl.js",
+    "mapbox-gl.css": "dist/mapbox-gl.css",
+  },
+  "mapillary-js": {
+    "mapillary.js": "dist/mapillary.js",
+    "mapillary.css": "dist/mapillary.css",
+  },
+  "osm-auth": { "osmauth.js": "osmauth.min.js" },
+  "osm-request": { "osmrequest.js": "dist/OsmRequest.js" },
+  pic4carto: { "pic4carto.js": "dist/P4C.min.js" },
+  "swiped-events": { "swiped-events.js": "dist/swiped-events.min.js" },
+  wordcloud: { "wordcloud.js": "src/wordcloud2.js" },
 };
 
-app.get('/lib/:modname/:file', (req, res) => {
-	if(!req.params.modname || !req.params.file) {
-		return res.status(400).send('Missing parameters');
-	}
-	else if(!authorized[req.params.modname] || !authorized[req.params.modname][req.params.file]) {
-		return res.status(404).send('File not found');
-	}
+app.get("/lib/:modname/:file", (req, res) => {
+  if (!req.params.modname || !req.params.file) {
+    return res.status(400).send("Missing parameters");
+  } else if (
+    !authorized[req.params.modname] ||
+    !authorized[req.params.modname][req.params.file]
+  ) {
+    return res.status(404).send("File not found");
+  }
 
-	const options = {
-		root: path.join(__dirname, '../node_modules'),
-		dotfiles: 'deny',
-		headers: {
-			'x-timestamp': Date.now(),
-			'x-sent': true
-		}
-	};
+  const options = {
+    root: path.join(__dirname, "../node_modules"),
+    dotfiles: "deny",
+    headers: {
+      "x-timestamp": Date.now(),
+      "x-sent": true,
+    },
+  };
 
-	const fileName = `${req.params.modname}/${authorized[req.params.modname][req.params.file]}`;
-	res.sendFile(fileName, options, (err) => {
-		if (err) {
-			res.status(err.status ? err.status : 500).end();
-		}
-	});
+  const fileName = `${req.params.modname}/${authorized[req.params.modname][req.params.file]}`;
+  res.sendFile(fileName, options, (err) => {
+    if (err) {
+      res.status(err.status ? err.status : 500).end();
+    }
+  });
 });
 
-app.use('/lib/fontawesome', express.static(path.join(__dirname, '../node_modules/@fortawesome/fontawesome-free')));
+app.use(
+  "/lib/fontawesome",
+  express.static(
+    path.join(__dirname, "../node_modules/@fortawesome/fontawesome-free"),
+  ),
+);
 
 // 404
 app.use((req, res) => {
-	if(CONFIG.MAINTENANCE_MODE === true) { return res.redirect('/'); }
-	res.redirect('/error/404');
+  if (CONFIG.MAINTENANCE_MODE === true) {
+    return res.redirect("/");
+  }
+  res.redirect("/error/404");
 });
 
 // Start
-pool.query('SELECT version()')
-.then(() => {
-	app.listen(port, () => {
-		console.log('API started on port: ' + port);
-	});
-})
-.catch(e => {
-	console.error("Can't connect to database :", e.message);
-});
+pool
+  .query("SELECT version()")
+  .then(() => {
+    app.listen(port, () => {
+      console.log("API started on port: " + port);
+    });
+  })
+  .catch((e) => {
+    console.error("Can't connect to database :", e.message);
+  });

--- a/website/index.js
+++ b/website/index.js
@@ -696,7 +696,7 @@ const authorized = {
     "mapillary.js": "dist/mapillary.js",
     "mapillary.css": "dist/mapillary.css",
   },
-  "osm-auth": { "osmauth.js": "osmauth.min.js" },
+  "osm-auth": { "osmauth.js": "dist/osm-auth.iife.js" },
   "osm-request": { "osmrequest.js": "dist/OsmRequest.js" },
   pic4carto: { "pic4carto.js": "dist/P4C.min.js" },
   "swiped-events": { "swiped-events.js": "dist/swiped-events.min.js" },

--- a/website/templates/common/head.pug
+++ b/website/templates/common/head.pug
@@ -49,24 +49,38 @@ if CONFIG
 	script.
 		Chart.defaults.global.defaultFontSize = 15;
 
-		const osmApi = new OsmRequest({
-			endpoint: "#{CONFIG.OSM_URL}",
-			oauthConsumerKey: "#{CONFIG.OSM_API_KEY}",
-			oauthSecret: "#{CONFIG.OSM_API_SECRET}"
-		});
+		const conf = {
+		  scope: "read_prefs write_api openid",
+		  client_id: "#{CONFIG.OSM_CLIENT_ID}",
+		  redirect_uri: window.location.origin + window.location.pathname,
+		  url: "#{CONFIG.OSM_URL}",
+		  apiUrl: "#{CONFIG.API_OSM_URL}",
+		  auto: true,
+		  singlepage: true
+		};
+
+		const osmApi = new OsmRequest(conf);
 
 		const authOpts = {
-			url: "#{CONFIG.OSM_URL}",
-			oauth_consumer_key: "#{CONFIG.OSM_API_KEY}",
-			oauth_secret: "#{CONFIG.OSM_API_SECRET}",
-			landing: window.location.href.replace(window.location.search, ""),
-			singlepage: true
+		  url: "#{CONFIG.OSM_URL}",
+		  apiUrl: "#{CONFIG.API_OSM_URL}",
+		  client_id: "#{CONFIG.OSM_CLIENT_ID}",
+		  singlepage: true,
+		  redirect_uri: window.location.origin + window.location.pathname,
+		  scope: "read_prefs write_api openid"
 		};
+
 		const auth = osmAuth(authOpts);
 		let authWait;
 
 		const params = new URLSearchParams((window.location.search || "?").substring(1));
 		const token = params.get("oauth_token") || localStorage.getItem("oauth_token") || null;
+
+		if (window.location.search.slice(1).split('&').some(p => p.startsWith('code='))) {
+			auth.authenticate(function() {
+				console.log("Auth success");
+			});
+		}
 
 		function checkAuth() {
 			if(auth.authenticated()) {

--- a/website/templates/common/head.pug
+++ b/website/templates/common/head.pug
@@ -50,11 +50,11 @@ if CONFIG
 		Chart.defaults.global.defaultFontSize = 15;
 
 		const conf = {
-		  scope: "read_prefs write_api openid",
+		  scope: "read_prefs write_api write_notes openid",
 		  client_id: "#{CONFIG.OSM_CLIENT_ID}",
-		  redirect_uri: window.location.origin + window.location.pathname,
+		  redirect_uri: window.location.origin,
 		  url: "#{CONFIG.OSM_URL}",
-		  apiUrl: "#{CONFIG.API_OSM_URL}",
+		  apiUrl: "#{CONFIG.OSM_API_URL}",
 		  auto: true,
 		  singlepage: true
 		};
@@ -62,15 +62,15 @@ if CONFIG
 		const osmApi = new OsmRequest(conf);
 
 		const authOpts = {
-		  url: "#{CONFIG.OSM_URL}",
-		  apiUrl: "#{CONFIG.API_OSM_URL}",
-		  client_id: "#{CONFIG.OSM_CLIENT_ID}",
-		  singlepage: true,
-		  redirect_uri: window.location.origin + window.location.pathname,
-		  scope: "read_prefs write_api openid"
+		  url: conf.url,
+		  apiUrl: conf.apiUrl,
+		  client_id: conf.client_id,
+		  singlepage: conf.singlepage,
+		  redirect_uri: conf.redirect_uri,
+		  scope: conf.scope,
 		};
 
-		const auth = osmAuth(authOpts);
+		const auth = osmAuth.osmAuth(authOpts);
 		let authWait;
 
 		const params = new URLSearchParams((window.location.search || "?").substring(1));
@@ -118,7 +118,7 @@ if CONFIG
 		}
 
 		function login() {
-			authOpts.landing = window.location.href + window.location.hash;
+			authOpts.redirect_uri = window.location.href;
 			auth.options(authOpts);
 
 			if(!auth.authenticated()) {


### PR DESCRIPTION
As notified in #312 osm deprecated Oauth 1.0,  there is few modifications to be able to use PDM again.

- Update sendfile_osm_oauth_protector submodule
- Update osm-auth
- Update osm-request