### PR TITLE
Fix openinframap url

### DIFF
--- a/projects/2018-07_substation/info.json
+++ b/projects/2018-07_substation/info.json
@@ -78,6 +78,6 @@
 		}
 	},
 	"opendata": [
-		{ "title": "Carte des infrastructures dont postes électriques", "via": "OpenInfraMap", "url": "https://openinframap.org/#15/45.9120/6.1275/Power" }
+		{ "title": "Carte des infrastructures dont postes électriques", "via": "OpenInfraMap", "url": "https://openinframap.org/#15/45.9120/6.1275" }
 	]
 }


### PR DESCRIPTION
Openinframap have changed urls without Power parameter, power and label layers are now visible.

CC @flacombe require to also update url in Enedis projects