### PR TITLE
Upgrade minimal requirements

### DIFF
--- a/DEVELOP.fr.md
+++ b/DEVELOP.fr.md
@@ -2,10 +2,10 @@
 
 ## Dépendances
 
-- NodeJS >= 12.9
+- NodeJS >= 18
 - Outils Bash : curl, awk, grep, sed, xsltproc, bc
-- PostgreSQL >= 10
-- Python 3
+- PostgreSQL >= 13
+- Python 3 (et le module `requests`)
 - [Osmium](https://osmcode.org/osmium-tool/) > 1.10
 - [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)
 - [Imposm](https://imposm.org/) >= 3
@@ -577,3 +577,5 @@ export DB_URL="postgres://user:password@host:5432/database" # Database URL
 export PORT=3000 # Nodejs port (defaults to 3000)
 npm run start
 ```
+
+Le site est accessible à cette url [localhost:3000](http://localhost:3000).

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,9 +2,9 @@
 
 ## Dependencies
 
-- NodeJS >= 12.9
+- NodeJS >= 18
 - Bash tools : curl, awk, grep, sed, xsltproc, bc
-- PostgreSQL >= 10
+- PostgreSQL >= 13
 - Python 3 (and `requests` module)
 - [Osmium](https://osmcode.org/osmium-tool/) > 1.10
 - [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:14.18.0-bullseye-slim
+FROM node:18.17.0-bullseye-slim
 
 ENV DB_URL=postgres://localhost:5432/osm
 ENV PORT=3000
 ARG IMPOSM3_VERSION=0.11.0
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN groupadd --gid 10001 -r osm \
     && useradd --uid 10001 -d /home/osm -m -r -s /bin/false -g osm osm \
     && mkdir -p /data/files/pdm /opt/pdm /opt/imposm3 \


### PR DESCRIPTION
This PR updates minimal requirements:
- Set 18.17.0 like the minimal version of node js (for website and docker server) -> I'm not sure users continue to use nodejs 12
- Set PostgreSQL 13 like minimal versions like specified in Dockerfile and docker-compose file
- Add requests module python requirements in french doc
- Add missing url of website at the end of the french doc
- Add new command in Dockerfile before download dependencies with apt like recommend [here](https://github.com/hadolint/hadolint/wiki/DL4006)

Just need help to test, I have tried with Github Actions, but I have error when I want build dockerfile