### PR TITLE
Meilleure gestion des boundaries

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -66,9 +66,7 @@ CREATE TABLE pdm_features_boundary (
 	project VARCHAR NOT NULL,
 	osmid VARCHAR NOT NULL,
 	version INT NOT NULL,
-	boundary BIGINT,
-
-	UNIQUE(project,osmid,version,boundary)
+	boundary BIGINT
 );
 
 CREATE INDEX ON pdm_features_boundary USING btree(project);

--- a/db/12_features_post_init.sql
+++ b/db/12_features_post_init.sql
@@ -1,6 +1,6 @@
 -- Boundary subdivide
 CREATE MATERIALIZED VIEW pdm_boundary_subdivide AS
-SELECT id, osm_id, name, admin_level, tags, ST_Subdivide(geom, 450) AS geom
+SELECT id, osm_id, name, admin_level, tags, ST_Subdivide(ST_Transform(geom, 4326), 450) AS geom
 FROM pdm_boundary;
 
 CREATE INDEX ON pdm_boundary_subdivide using gist(geom);

--- a/db/20_changes_update.js
+++ b/db/20_changes_update.js
@@ -150,20 +150,17 @@ if [[ "\$mode" = "init" ]]; then
 
         echo "== Download OSH PBF file"
         wget --progress=dot:giga -N --no-cookies --header "Cookie: $(cat "${COOKIES_FS}" | cut -d ';' -f 1)" -P "${CONFIG.WORK_DIR}" -O "${OSH_PBF_FS}" "${CONFIG.OSH_PBF_URL}"
-        rm -f "${COOKIES_FS}"
-
-        echo "== Read OSH file information..."
-        osh_ts=\$(osmium fileinfo -e -g data.timestamp.last "${OSH_PBF_FS}")
-        rm -f "${OSH_TS_FS}"
-        echo \$osh_ts > "${OSH_TS_FS}"
+        rm -f "${COOKIES_FS}" "${OSH_TS_FS}"
     else
         echo "OSH file exists"
-        if [ ! -f "${OSH_TS_FS}" ]; then
-            osh_ts=\$(osmium fileinfo -e -g data.timestamp.last "${OSH_PBF_FS}")
-            echo \$osh_ts > "${OSH_TS_FS}"
-        else
-            osh_ts=\$(cat "${OSH_TS_FS}")
-        fi
+    fi
+
+    if [ ! -f "${OSH_TS_FS}" ]; then
+        echo "== Read OSH file information..."
+        osh_ts=\$(osmium fileinfo -e -g data.timestamp.last "${OSH_PBF_FS}")
+        echo \$osh_ts > "${OSH_TS_FS}"
+    else
+        osh_ts=\$(cat "${OSH_TS_FS}")
     fi
 
     if [ ! -f "${POLY_FS}" ]; then

--- a/db/22_changes_populate.sql
+++ b/db/22_changes_populate.sql
@@ -6,3 +6,5 @@ SELECT *
 FROM pdm_changes_tmp
 ON CONFLICT (project,osmid,version)
 DO UPDATE SET tags=EXCLUDED.tags, ts=EXCLUDED.ts, username=EXCLUDED.username, action=EXCLUDED.action;
+
+CREATE INDEX ON pdm_changes_tmp using gist(geom);

--- a/db/23_changes_boundary.sql
+++ b/db/23_changes_boundary.sql
@@ -1,14 +1,17 @@
 -- Insert unknown changes from pdm_changes_tmp and associate them with enclosing boundaries
+ALTER TABLE pdm_features_boundary SET UNLOGGED;
 WITH unknown AS (
 	SELECT pc.osmid AS osmid,
-	pc.version as version
-	b.osm_id AS boundary,
+	pc.version as version,
+	b.osm_id AS boundary
 	FROM pdm_changes_tmp pc
-	LEFT JOIN pdm_features_boundary fb ON fb.project=:project_id AND fb.osmid=pc.osmid AND fb.version=pc.version
 	JOIN pdm_boundary_subdivide b ON ST_Intersects(pc.geom, b.geom)
+	LEFT JOIN pdm_features_boundary fb ON fb.project=:project_id AND fb.osmid=pc.osmid AND fb.version=pc.version AND fb.boundary=b.osm_id
 	WHERE fb.osmid IS NULL
-	GROUP BY pc.osmid, pc.version, b.osm_id
 )
 INSERT INTO pdm_features_boundary
 SELECT :project_id AS project, u.osmid AS osmid, u.version, u.boundary
 FROM unknown u;
+
+ALTER TABLE pdm_features_boundary SET LOGGED;
+REINDEX table pdm_features_boundary;

--- a/db/osc2csv.awk
+++ b/db/osc2csv.awk
@@ -74,7 +74,7 @@ BEGIN {
         if (a != "delete"){
             x = substr($9, 2);     # Longitude
             y = substr($10, 2);    # Latitude
-            g = "POINT("x" "y")"
+            g = "SRID=4326; POINT("x" "y")"
         }
     } else if (f == "w"){
         f = "way"


### PR DESCRIPTION
Les changement suivants améliorent la gestion des périmètres administratifs :
- Migration vers l'EPSG 4326 pour les subdivisions et géométries des changes (nul besoin de les présenter sur une carte)
- Amélioration des performances lors de la mise à jour des projets

Ces modifications donnent satisfaction dans l'initialisation et le calcul des projets Enedis que je viens de remettre en ligne avec les nouveaux traitements.

Le compte par zone est un succès, on voit désormais fidèlement les comptes augmenter et baisser !
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/7feb0416-6440-4c0e-a1c6-3cae28aa3df5" />
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/4a40421a-652c-4c72-98e6-959e532bbffd" />

Fix #244 