### PR TITLE
Distinguish in website soft/hard project ends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /db/13_points.sql
 /.idea
 /osmium
+/launcher.sh

--- a/docs/DEVELOP.fr.md
+++ b/docs/DEVELOP.fr.md
@@ -90,6 +90,7 @@ Les propriétés dans `info.json` sont les suivantes :
 - `title` : nom de la mission (assez court)
 - `start_date` : date de début de la mission (format AAAA-MM-JJ)
 - `end_date` : date de fin de la mission (format AAAA-MM-JJ)
+- `soft_end_date`: date de fin de la période de _forte_ animation communautaire (format AAAA-MM-JJ). Donnée purement à titre informatif, n'affecte pas le traitement des données.
 - `summary` : résumé de la mission
 - `links` : définition des URL pour les liens vers des pages tierces (wiki OSM)
 - `database.osmium_tag_filter` : filtre Osmium sur les tags à appliquer pour ne conserver que les objets OSM pertinents (par exemple `nwr/*:covid19`, [syntaxe décrite ici](https://osmcode.org/osmium-tool/manual.html#filtering-by-tags)). Il est possible d'enchaîner plusieurs filtres par & et en répétant l'indication de primitive à chaque niveau. L'opérateur != n'est pour l'instant pas pris en compte.

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -90,6 +90,7 @@ The properties in `info.json` are as follows:
 - `title`: name of the mission (short enough)
 - `start_date`: start date of the mission (format YYYYY-MM-DD)
 - `end_date`: end date of the mission (format YYYYY-MM-DD)
+- `soft_end_date`: end date of the _strong_ community animation period (format YYYYY-MM-DD). This is only informational, it doesn't affect backend processing.
 - `summary`: summary of the mission
 - `links`: definition of the URLs for links to third party pages (OSM wiki)
 - `database.osmium_tag_filter` : Osmium filter on the tags to be applied to keep only the relevant OSM objects (for example `nwr/*:covid19`, [syntax described here](https://osmcode.org/osmium-tool/manual.html#filtering-by-tags)). It is possible to list many filters using `&` character and same syntax.

--- a/website/index.js
+++ b/website/index.js
@@ -439,6 +439,17 @@ app.get("/projects/:id/stats", (req, res) => {
       })),
   );
 
+  // Fetch last count update time
+  allPromises.push(
+    pool
+      .query(`SELECT counts_lastupdate_date FROM pdm_projects WHERE project = $1`, [
+        req.params.id,
+      ])
+      .then((results) => ({
+        lastUpdate: results.rows?.length > 0 && results.rows[0].counts_lastupdate_date,
+      })),
+  );
+
   // Fetch tags statistics
   allPromises.push(
     pool

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -145,5 +145,6 @@
 	"Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap.": "Find all data directly on OpenStreetMap website.",
 	"A propos": "About",
 	"Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.": "This project has ended, but mapping in OpenStreetMap goes on! You can contribute on other topics.",
-	"Projet terminé": "Project ended"
+	"Projet terminé": "Project ended",
+	"Dernière mise à jour : ": "Last update: "
 }

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -143,5 +143,7 @@
 	"Veuillez réessayer un peu plus tard, merci pour votre compréhension.": "Please try again later, thanks for your understanding.",
 	"Plus d'infos sur ce champ": "More details about this field",
 	"Retrouvez l'ensemble des données directement sur le site d'OpenStreetMap.": "Find all data directly on OpenStreetMap website.",
-	"A propos": "About"
+	"A propos": "About",
+	"Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.": "This project has ended, but mapping in OpenStreetMap goes on! You can contribute on other topics.",
+	"Projet terminé": "Project ended"
 }

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -153,5 +153,6 @@
 	"Tous nos projets": "Tous nos projets",
 	"Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.": "Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.",
 	"Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.": "Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.",
-	"Projet terminé": "Projet terminé"
+	"Projet terminé": "Projet terminé",
+	"Dernière mise à jour : ": "Dernière mise à jour : "
 }

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -151,5 +151,7 @@
 	"À propos": "À propos",
 	"En ce moment : %s projets prioritaires": "En ce moment : %s projets prioritaires",
 	"Tous nos projets": "Tous nos projets",
-	"Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.": "Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données."
+	"Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.": "Retrouvez l'ensemble des projets du mois, leurs outils, statistiques et données.",
+	"Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.": "Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.",
+	"Projet terminé": "Projet terminé"
 }

--- a/website/templates/components/stats.pug
+++ b/website/templates/components/stats.pug
@@ -1,3 +1,7 @@
+//- Last update
+div.row
+	div.col-12.mb-2#stats-update
+
 //- Synthetic stats
 div.row.mb-4#stats-blocks
 	div.col.text-center
@@ -52,6 +56,11 @@ script.
 		fetch("/projects/#{id}/stats"+(window.osm_user ? "?osm_user="+window.osm_user.name : ""))
 		.then(res => res.json())
 		.then(res => {
+			// Last stats update time
+			const lastUpdate = document.getElementById("stats-update");
+			lastUpdate.innerHTML = "#{__("Dernière mise à jour : ")}" + (new Date(res.lastUpdate)).toLocaleDateString();
+
+			// Blocks for small stats
 			const blocks = document.getElementById("stats-blocks");
 			blocks.innerHTML = '';
 			const addBlock = (title, subtitle) => {
@@ -75,7 +84,6 @@ script.
 				blocks.appendChild(b);
 			};
 
-			// Blocks for small stats
 			if(res.added) { addBlock(numberFormat.format(res.added), "#{title.toLowerCase()} ajoutés"); }
 			if(res.count) { addBlock(numberFormat.format(res.count), "#{title.toLowerCase()} au total dans OSM"); }
 			if(res.tasksSolved !== undefined) { addBlock(numberFormat.format(res.tasksSolved), "#{statistics.osmose_tasks}"); }

--- a/website/templates/pages/project.pug
+++ b/website/templates/pages/project.pug
@@ -38,15 +38,18 @@ block content
 					h1.font-italic.mb-0= title
 					p.pdm-project-date.text-capitalize.mb-0.mb-md-2= new Date(month).toLocaleString(getLocale(), { month: 'long', year: 'numeric' })
 
-			div.btn-over-wide.d-flex.justify-content-center.align-items-center
-				a.pdm-wide-link.map(href=`/projects/${id}/map`)
-				a.btn.btn-primary.btn-lg(style="color: white")
-					i.fa.fa-pen.mr-2
-					| #{__("Contribuer")}
+			if !isHardEnded
+				div.btn-over-wide.d-flex.justify-content-center.align-items-center
+					a.pdm-wide-link.map(href=`/projects/${id}/map`)
+					a.btn.btn-primary.btn-lg(style="color: white")
+						i.fa.fa-pen.mr-2
+						| #{__("Contribuer")}
+			else
+				p= __("Projet terminé")
 
 			p.lead.mb-0.mt-md-2= summary
 
-	if isRecentPast
+	if isRecentPast || isHardEnded
 		div.container-fluid.py-5.pdm-section-highlight
 			div.blog-post.container
 				h2.blog-post-title.mb-2
@@ -62,9 +65,10 @@ block content
 					wordsTmp.unshift(["#{__("Merci !")}", 50]);
 					createWordCloud(document.getElementById("word-cloud"), wordsTmp);
 
-				a.btn.btn-primary.btn-lg.my-2(href="#statistics")
-					i.fa.fa-chart-bar.mr-2
-					| #{__("Voir les statistiques")}
+				div.text-center
+					a.btn.btn-primary.btn-lg.my-2(href="#statistics")
+						i.fa.fa-chart-bar.mr-2
+						| #{__("Voir les statistiques")}
 
 	a#contribute
 	div.container-fluid.py-5
@@ -76,18 +80,27 @@ block content
 			if isNext
 				p= __("Ce projet du mois commencera le %s, mais il n'est jamais trop tôt pour se lancer ! Vous pouvez commencer dès à présent à enrichir les données à l'aide de nos outils et de la documentation.", new Date(start_date).toLocaleString(getLocale(), { day: "numeric", month: "long" }))
 			else if !isActive
-				p= __("Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez continuer à enrichir les données à l'aide de nos outils et de la documentation.")
+				if isHardEnded
+					p= __("Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez contribuer à d'autres thématiques.")
+				else
+					p= __("Ce projet du mois est terminé, mais la cartographie dans OpenStreetMap ne s'arrête pas ! Vous pouvez continuer à enrichir les données à l'aide de nos outils et de la documentation.")
 
-			div.mt-3!= howto
-			div.text-center
-				a.btn.btn-primary.btn-lg.m-1(style="color: white" href=`/projects/${id}/map`)
-					i.fa.fa-pen.mr-2
-					| #{__("Contribuer")}
-				if links.osmwiki
-					a.btn.btn-secondary.btn-lg.m-1(href=links.osmwiki target="_blank" role="button")
-						i.fa.fa-book.mr-2
-						| #{__("Documentation complète")}
-				if links.osmblog
+			if !isHardEnded
+				div.mt-3!= howto
+				div.text-center
+					a.btn.btn-primary.btn-lg.m-1(style="color: white" href=`/projects/${id}/map`)
+						i.fa.fa-pen.mr-2
+						| #{__("Contribuer")}
+					if links.osmwiki
+						a.btn.btn-secondary.btn-lg.m-1(href=links.osmwiki target="_blank" role="button")
+							i.fa.fa-book.mr-2
+							| #{__("Documentation complète")}
+					if links.osmblog
+						a.btn.btn-secondary.btn-lg.m-1(href=links.osmblog target="_blank" role="button")
+							i.fa.fa-rss.mr-2
+							| #{__("Article de blog")}
+			else if isHardEnded && links.osmblog
+				div.text-center
 					a.btn.btn-secondary.btn-lg.m-1(href=links.osmblog target="_blank" role="button")
 						i.fa.fa-rss.mr-2
 						| #{__("Article de blog")}

--- a/website/utils.js
+++ b/website/utils.js
@@ -50,18 +50,22 @@ exports.foldProjects = (projects) => {
 	const prjs = { past: [], current: [], next: [] };
 	Object.values(projects).forEach(project => {
 		// Check dates
-		if(new Date(project.start_date).getTime() <= Date.now() && (project.end_date == null || Date.now() <= new Date(project.end_date+"T23:59:59Z").getTime())) {
+		if(new Date(project.start_date).getTime() <= Date.now() && ((project.end_date == null && project.soft_end_date == null) || Date.now() <= new Date(project.end_date+"T23:59:59Z").getTime())) {
 			prjs.current.push(project);
 		}
 		else if(Date.now() <= new Date(project.start_date).getTime()) {
 			prjs.next.push(project);
 		}
-		else if(project.end_date != null && new Date(project.end_date+"T23:59:59Z").getTime() < Date.now()) {
+		else if(
+			(project.end_date != null && new Date(project.end_date+"T23:59:59Z").getTime() < Date.now())
+			|| (project.end_date == null && project.soft_end_date != null && new Date(project.soft_end_date+"T23:59:59Z").getTime() < Date.now())
+		) {
 			prjs.past.push({
 				id: project.id,
 				icon: `/images/badges/${project.id.split("_").pop()}.svg`,
 				title: project.title,
-				month: project.month
+				month: project.month,
+				end_date: project.end_date,
 			});
 		}
 	});


### PR DESCRIPTION
Modification du front pour une meilleure lisibilité des projets "terminés" :

- Projet _fini-fini_ (`end_date` renseigné / `soft_end_date` vide) : carte de contribution désactivée, wording un peu différent
- Projet qui continue sa vie en autonomie (`end_date` vide / `soft_end_date` renseigné) : carte de contribution toujours active, wording identique à précédemment. Projet dans la liste des projets passés sur la page d'accueil
- Projet en cours (`end_date` vide / `soft_end_date` vide) : mis en avant sur l'accueil

Déployé sur projetdumois.fr @flacombe si tu veux tester, tous les projets sont en `end_date=null + soft_end_date=renseigné` sauf horaires durant le covid.