### PR TITLE
Add systematic mapper counts per project similar to features counts

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -40,7 +40,7 @@ CREATE INDEX ON pdm_user_contribs(userid);
 -- User badges
 DROP TABLE IF EXISTS pdm_user_badges;
 
--- Features overall counts
+-- Overall counts
 CREATE TABLE pdm_feature_counts(
 	project_id int NOT NULL,
 	ts TIMESTAMP NOT NULL,
@@ -48,10 +48,51 @@ CREATE TABLE pdm_feature_counts(
 	amount INT NOT NULL,
 	len numeric not null,
 
-	CONSTRAINT pdm_feature_counts_unique UNIQUE(project_id,ts,label)
+	CONSTRAINT pdm_feature_counts_unique UNIQUE NULLS NOT DISTINCT(project_id,ts,label)
 );
 
 CREATE INDEX ON pdm_feature_counts(project_id);
+
+CREATE TABLE pdm_mapper_counts(
+	project_id int NOT NULL,
+	ts TIMESTAMP NOT NULL,
+	label varchar,
+	amount_1d INT NOT NULL,
+	amount_30d INT NOT NULL,
+
+	CONSTRAINT pdm_mapper_counts_unique UNIQUE NULLS NOT DISTINCT(project_id,ts,label)
+);
+
+CREATE INDEX ON pdm_mapper_counts(project_id);
+
+-- Boundary counts
+CREATE TABLE pdm_feature_counts_per_boundary(
+	project_id int NOT NULL,
+	boundary BIGINT NOT NULL,
+	ts TIMESTAMP NOT NULL,
+	label varchar,
+	amount INT NOT NULL,
+	len numeric not null,
+
+	CONSTRAINT pdm_feature_counts_per_boundary_unique UNIQUE NULLS NOT DISTINCT(project_id, boundary, ts, label)
+);
+
+CREATE INDEX ON pdm_feature_counts_per_boundary using btree (project_id);
+CREATE INDEX ON pdm_feature_counts_per_boundary using btree (boundary);
+
+CREATE TABLE pdm_mapper_counts_per_boundary(
+	project_id int NOT NULL,
+	boundary BIGINT NOT NULL,
+	ts TIMESTAMP NOT NULL,
+	label varchar,
+	amount_1d INT NOT NULL,
+	amount_30d INT NOT NULL,
+
+	CONSTRAINT pdm_mapper_counts_per_boundary_unique UNIQUE NULLS NOT DISTINCT(project_id, boundary, ts, label)
+);
+
+CREATE INDEX ON pdm_mapper_counts_per_boundary using btree (project_id);
+CREATE INDEX ON pdm_mapper_counts_per_boundary using btree (boundary);
 
 -- Note counts
 CREATE TABLE pdm_note_counts(
@@ -62,20 +103,6 @@ CREATE TABLE pdm_note_counts(
 );
 
 CREATE INDEX ON pdm_note_counts(project_id);
-
-CREATE TABLE pdm_feature_counts_per_boundary(
-	project_id int NOT NULL,
-	boundary BIGINT NOT NULL,
-	ts TIMESTAMP NOT NULL,
-	label varchar,
-	amount INT NOT NULL,
-	len numeric not null,
-
-	CONSTRAINT pdm_feature_counts_per_boundary_unique UNIQUE(project_id, boundary, ts, label)
-);
-
-CREATE INDEX ON pdm_feature_counts_per_boundary using btree (project_id);
-CREATE INDEX ON pdm_feature_counts_per_boundary using btree (boundary);
 
 -- Leaderboard view
 CREATE OR REPLACE VIEW pdm_leaderboard AS

--- a/db/30_projects_update.js
+++ b/db/30_projects_update.js
@@ -241,7 +241,7 @@ else
 
     script += `
     echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Generate user contributions"
-    ${PSQL} -v project_id="${project.id}" -v project_table="pdm_features_${slug}" -v start_date="'\${process_start_ts}'" -v end_date="'\${process_end_ts}'" -f "${__dirname}/33_projects_contribs.sql"
+    ${PSQL} -v project_id="${project.id}" -v features_table="pdm_features_${slug}" -v boundary_table="pdm_features_${slug}_boundary" -v labels_table="pdm_features_${slug}_labels"  -v start_date="'\${process_start_ts}'" -v end_date="'\${process_end_ts}'" -v dates_list="\$count_dates_list" -f "${__dirname}/33_projects_contribs.sql"
 
     if [ -f '${__dirname}/../projects/${project.name}/extract.sh' ]; then
         echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Extract script"

--- a/db/33_projects_contribs.sql
+++ b/db/33_projects_contribs.sql
@@ -1,30 +1,101 @@
 -- Update user names
 \timing
 ANALYSE pdm_user_names;
-ANALYSE :project_table;
+ANALYSE :features_table;
 
-WITH filtered_users AS (
-  SELECT DISTINCT userid, username
-  FROM :project_table
-  WHERE ts BETWEEN :start_date AND :end_date
-    AND userid IS NOT NULL
+WITH unknown_users AS (
+  SELECT DISTINCT un.userid, un.username
+  FROM :features_table f
+  LEFT JOIN pdm_user_names un ON un.userid=f.userid
+  WHERE f.ts BETWEEN :start_date AND :end_date
+    AND f.userid IS NOT NULL
     AND tagsfilter
+    AND un.username IS NULL
 )
 INSERT INTO pdm_user_names
-SELECT fu.userid, fu.username
-FROM filtered_users fu
-WHERE NOT EXISTS (
-  SELECT 1 FROM pdm_user_names u
-  WHERE u.userid = fu.userid
-);
+SELECT u.userid, u.username
+FROM unknown_users u;
 
 -- Establishing user contributions in every running project
 DELETE FROM pdm_user_contribs WHERE project_id=:project_id AND ts >= :start_date;
 
 INSERT INTO pdm_user_contribs(project_id, userid, ts, contribution, amount, points)
 	SELECT :project_id as project_id, f.userid, f.ts::date, f.contrib AS contribution, COUNT(*) AS amount, SUM(pp.points) AS points
-	FROM :project_table f
+	FROM :features_table f
 	JOIN pdm_projects_points pp ON f.contrib=pp.contrib
 
 	WHERE pp.project_id=:project_id AND f.ts BETWEEN :start_date AND :end_date AND f.tagsfilter=true
 	GROUP BY f.userid, f.contrib, f.ts::date;
+
+-- Handle dates list
+CREATE TEMP TABLE IF NOT EXISTS pdm_mapper_counts_dates (ts timestamp, ts1d timestamp, ts30d timestamp); TRUNCATE TABLE pdm_mapper_counts_dates;
+INSERT INTO pdm_mapper_counts_dates (ts) VALUES :dates_list;
+UPDATE pdm_mapper_counts_dates SET ts1d=ts - interval '1 day', ts30d=ts - interval '30 days';
+CREATE INDEX ON pdm_mapper_counts_dates using btree(ts);
+CREATE INDEX ON pdm_mapper_counts_dates using btree(ts1d);
+CREATE INDEX ON pdm_mapper_counts_dates using btree(ts30d);
+
+-- Main labels count
+INSERT INTO pdm_mapper_counts (project_id, ts, label, amount_1d, amount_30d)
+  SELECT
+      :project_id AS project_id,
+      d.ts,
+      fl.label,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts1d AND d.ts THEN f.userid END) AS amount_1d,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts30d AND d.ts THEN f.userid END) AS amount_30d
+  FROM :features_table f
+  JOIN :labels_table fl ON fl.osmid=f.osmid and fl.version=f.version
+  JOIN pdm_mapper_counts_dates d ON f.ts BETWEEN d.ts30d AND d.ts
+  WHERE f.tagsfilter = true
+  GROUP BY d.ts, fl.label
+ON CONFLICT (project_id, ts, label) DO UPDATE SET amount_1d=EXCLUDED.amount_1d, amount_30d=EXCLUDED.amount_30d;
+
+-- Main rollup count
+INSERT INTO pdm_mapper_counts (project_id, ts, label, amount_1d, amount_30d)
+  SELECT
+      :project_id AS project_id,
+      d.ts,
+      null as label,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts1d AND d.ts THEN f.userid END) AS amount_1d,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts30d AND d.ts THEN f.userid END) AS amount_30d
+  FROM :features_table f
+  JOIN pdm_mapper_counts_dates d ON f.ts BETWEEN d.ts30d AND d.ts
+  WHERE f.tagsfilter = true
+  GROUP BY d.ts
+ON CONFLICT (project_id, ts, label) DO UPDATE SET amount_1d=EXCLUDED.amount_1d, amount_30d=EXCLUDED.amount_30d;
+
+-- Boundary labels count
+INSERT INTO pdm_mapper_counts_per_boundary (project_id, boundary, ts, label, amount_1d, amount_30d)
+  SELECT
+      :project_id AS project_id,
+      fb.boundary as boundary,
+      d.ts,
+      fl.label,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts1d AND d.ts THEN f.userid END) AS amount_1d,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts30d AND d.ts THEN f.userid END) AS amount_30d
+  FROM :features_table f
+  JOIN :labels_table fl ON fl.osmid=f.osmid and fl.version=f.version
+  JOIN :boundary_table fb ON fb.osmid=f.osmid AND fb.version=f.version
+  JOIN pdm_mapper_counts_dates d ON f.ts BETWEEN d.ts30d AND d.ts
+  WHERE f.tagsfilter = true
+  GROUP BY fb.boundary, d.ts, fl.label
+ON CONFLICT (project_id, boundary, ts, label) DO UPDATE SET amount_1d=EXCLUDED.amount_1d, amount_30d=EXCLUDED.amount_30d;
+
+-- Boundary rollup count
+INSERT INTO pdm_mapper_counts_per_boundary (project_id, boundary, ts, label, amount_1d, amount_30d)
+  SELECT
+      :project_id AS project_id,
+      fb.boundary as boundary,
+      d.ts,
+      null as label,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts1d AND d.ts THEN f.userid END) AS amount_1d,
+      COUNT(DISTINCT CASE WHEN f.ts BETWEEN d.ts30d AND d.ts THEN f.userid END) AS amount_30d
+  FROM :features_table f
+  JOIN :boundary_table fb ON fb.osmid=f.osmid AND fb.version=f.version
+  JOIN pdm_mapper_counts_dates d ON f.ts BETWEEN d.ts30d AND d.ts
+  WHERE f.tagsfilter = true
+  GROUP BY fb.boundary, d.ts
+ON CONFLICT (project_id, boundary, ts, label) DO UPDATE SET amount_1d=EXCLUDED.amount_1d, amount_30d=EXCLUDED.amount_30d;
+
+-- Clean up
+DROP TABLE pdm_mapper_counts_dates;

--- a/db/34_projects_init.sql
+++ b/db/34_projects_init.sql
@@ -1,5 +1,7 @@
 DELETE FROM pdm_feature_counts WHERE project_id=:project_id;
 DELETE FROM pdm_feature_counts_per_boundary WHERE project_id=:project_id;
+DELETE FROM pdm_mapper_counts WHERE project_id=:project_id;
+DELETE FROM pdm_mapper_counts_per_boundary WHERE project_id=:project_id;
 DELETE FROM pdm_note_counts WHERE project_id=:project_id;
 DELETE FROM pdm_user_contribs WHERE project_id=:project_id;
 UPDATE pdm_projects SET counts_lastupdate_date=NULL WHERE project_id=:project_id;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pgsqldb:
-    image: camptocamp/postgres:13-postgis-3
+    image: camptocamp/postgres:16-postgis-3
     restart: always
     networks:
       - oim-internal

--- a/docs/DEVELOP.fr.md
+++ b/docs/DEVELOP.fr.md
@@ -2,11 +2,11 @@
 
 ## Dépendances
 
-- NodeJS >= 18
+- NodeJS >= 24
 - Outils Bash : curl, mawk, grep, sed, bc
-- PostgreSQL >= 13
+- PostgreSQL >= 15
 - Python 3 (et le module `requests`)
-- [Osmium](https://osmcode.org/osmium-tool/) > 1.10
+- [Osmium](https://osmcode.org/osmium-tool/) > 1.18
 - [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)
 - [Imposm](https://imposm.org/) >= 3
 - [pg_tileserv](https://github.com/CrunchyData/pg_tileserv)
@@ -180,7 +180,6 @@ Toutefois, il est possible manuellement de supprimer puis attribuer à nouveau u
 ```bash
 psql -d postgresql://... -c "DELETE FROM pdm_features_project_labels WHERE label='label1'"
 psql -d postgresql://... -v features_table="pdm_features_project" -v labels_table="pdm_features_project_labels" -v label="'label1'" -v labelfilter="'... new label filer ...'" -f "db/27_changes_labels.sql"
-psql -d postgresql://... -c "ANALYSE pdm_features_project_labels"
 ```
 
 La phase `update_projects` devra ensuite être réinitialisée à son tour pour prendre en compte les nouveaux dénombrements.

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -2,11 +2,11 @@
 
 ## Dependencies
 
-- NodeJS >= 18
+- NodeJS >= 24
 - Bash tools : curl, mawk, grep, sed, bc
-- PostgreSQL >= 13
+- PostgreSQL >= 15
 - Python 3 (and `requests` module)
-- [Osmium](https://osmcode.org/osmium-tool/) > 1.10
+- [Osmium](https://osmcode.org/osmium-tool/) > 1.18
 - [osmctools](https://wiki.openstreetmap.org/wiki/Osmupdate)
 - [Imposm](https://imposm.org/) >= 3
 - [pg_tileserv](https://github.com/CrunchyData/pg_tileserv)
@@ -180,7 +180,6 @@ However, it is possible to manually delete and do the assignment of a particular
 ```bash
 psql -d postgresql://... -c "DELETE FROM pdm_features_project_labels WHERE label='label1'"
 psql -d postgresql://... -v features_table="pdm_features_project" -v labels_table="pdm_features_project_labels" -v label="'label1'" -v labelfilter="'... new label filer ...'" -f "db/27_changes_labels.sql"
-psql -d postgresql://... -c "ANALYSE pdm_features_project_labels"
 ```
 
 Then, the `update_projects` should be inited again to propagate the new labels into counts and KPI.


### PR DESCRIPTION
I propose to count mappers like we count features.
We complete counting process with corresponding queries and add an API to let access to data.
Mappers are counted on two period on each date: 24h and 30d

Following tables should be created on an existing database:

```sql
CREATE TABLE pdm_mapper_counts(
	project_id int NOT NULL,
	ts TIMESTAMP NOT NULL,
	label varchar,
	amount_1d INT NOT NULL,
	amount_30d INT NOT NULL,

	CONSTRAINT pdm_mapper_counts_unique UNIQUE(project_id,ts,label)
);
CREATE INDEX ON pdm_mapper_counts(project_id);

CREATE TABLE pdm_mapper_counts_per_boundary(
	project_id int NOT NULL,
	boundary BIGINT NOT NULL,
	ts TIMESTAMP NOT NULL,
	label varchar,
	amount_1d INT NOT NULL,
	amount_30d INT NOT NULL,

	CONSTRAINT pdm_mapper_counts_per_boundary_unique UNIQUE(project_id, boundary, ts, label)
);

CREATE INDEX ON pdm_mapper_counts_per_boundary using btree (project_id);
CREATE INDEX ON pdm_mapper_counts_per_boundary using btree (boundary);
```

Data is accessible on URL like:
https://mapyourgrid.infos-reseaux.com/projects/2025-01_substations/mappers/boundary/2202162

Process is extendable with further counts as necessary.
Fix #330 
Fix #359 
Fix #360 

Final tests are going on tonight. PR will be ready tomorrow