### PR TITLE
Fix flaws in geometries rebuild with changeset id on features

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -47,6 +47,7 @@ CREATE TABLE pdm_feature_counts(
 	label varchar,
 	amount INT NOT NULL,
 	len numeric not null,
+	area numeric not null,
 
 	CONSTRAINT pdm_feature_counts_unique UNIQUE NULLS NOT DISTINCT(project_id,ts,label)
 );
@@ -73,7 +74,8 @@ CREATE TABLE pdm_feature_counts_per_boundary(
 	label varchar,
 	amount INT NOT NULL,
 	len numeric not null,
-
+	area numeric not null,
+	
 	CONSTRAINT pdm_feature_counts_per_boundary_unique UNIQUE NULLS NOT DISTINCT(project_id, boundary, ts, label)
 );
 

--- a/db/22_changes_init.sql
+++ b/db/22_changes_init.sql
@@ -3,6 +3,7 @@ CREATE TABLE :features_table (
 	osmid VARCHAR NOT NULL,
 	version INT NOT NULL,
 	ts TIMESTAMP NOT NULL,
+	changeset bigint,
 	username VARCHAR,
 	userid BIGINT,
 	tags JSONB,
@@ -23,22 +24,22 @@ CREATE TABLE :members_table (
 DROP MATERIALIZED VIEW IF EXISTS :changes_table;
 CREATE MATERIALIZED VIEW :changes_table as
     SELECT
-    c1.osmid,
-    c1.version,
-    c1.ts as ts_start,
-    c2.ts as ts_end,
-    c1.username,
-    c1.userid,
-    c1.tags,
-    c1.action,
-    c1.contrib,
-    c1.tagsfilter,
-    c1.geom,
-    CASE when c1.geom is not null then St_Length(c1.geom::geography) else 0 end as geom_len
-    FROM :features_table c1 
-    LEFT JOIN :features_table c2
-		ON c1.osmid=c2.osmid and c1.version=c2.version-1
-	WHERE c1.action!='delete';
+    osmid,
+    version,
+	changeset,
+    ts as ts_start,
+	LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
+    username,
+    userid,
+    tags,
+    action,
+    contrib,
+    tagsfilter,
+    geom,
+    CASE when geom is not null then St_Length(geom::geography) else 0 end as geom_len,
+	CASE when geom is not null and ST_IsClosed(geom) then St_Area(geom::geography) else 0 end as geom_area
+    FROM :features_table
+	WHERE action!='delete';
 
 -- Associate a given feature/version to a label
 DROP TABLE IF EXISTS :labels_table CASCADE;

--- a/db/32_projects_counts.sql
+++ b/db/32_projects_counts.sql
@@ -9,8 +9,8 @@ INSERT INTO pdm_features_counts_dates (ts) VALUES :dates_list;
 CREATE INDEX ON pdm_features_counts_dates using btree(ts);
 
 -- Main labels count
-INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len)
-    SELECT :project_id as project_id, d.ts, fl.label as label, count(fc.osmid) as amount, sum(fc.geom_len) as len
+INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len, area)
+    SELECT :project_id as project_id, d.ts, fl.label as label, count(fc.osmid) as amount, sum(fc.geom_len) as len, sum(fc.geom_area) as area
     FROM :changes_table fc
     JOIN pdm_features_counts_dates d
     ON d.ts BETWEEN fc.ts_start AND fc.ts_end
@@ -21,8 +21,8 @@ INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len)
 ON CONFLICT (project_id, ts, label) DO UPDATE SET amount=EXCLUDED.amount, len=EXCLUDED.len;
 
 -- Main rollup count
-INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len)
-    SELECT :project_id as project_id, d.ts, null as label, count(fc.osmid) as amount, sum(fc.geom_len) as len
+INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len, area)
+    SELECT :project_id as project_id, d.ts, null as label, count(fc.osmid) as amount, sum(fc.geom_len) as len, sum(fc.geom_area) as area
     FROM :changes_table fc
     JOIN pdm_features_counts_dates d
     ON d.ts BETWEEN fc.ts_start AND fc.ts_end
@@ -32,8 +32,8 @@ INSERT INTO pdm_feature_counts (project_id, ts, label, amount, len)
 ON CONFLICT (project_id, ts, label) DO UPDATE SET amount=EXCLUDED.amount, len=EXCLUDED.len;
 
 -- Boundary labels count
-INSERT INTO pdm_feature_counts_per_boundary (project_id, boundary, ts, label, amount, len)
-    SELECT :project_id as project_id, fb.boundary, d.ts, fl.label as label, count(fc.osmid) as amount, sum(fc.geom_len) as len
+INSERT INTO pdm_feature_counts_per_boundary (project_id, boundary, ts, label, amount, len, area)
+    SELECT :project_id as project_id, fb.boundary, d.ts, fl.label as label, count(fc.osmid) as amount, sum(fc.geom_len) as len, sum(fc.geom_area) as area
     FROM :changes_table fc
     JOIN :boundary_table fb ON fb.osmid=fc.osmid AND fb.version=fc.version
     JOIN pdm_features_counts_dates d
@@ -45,8 +45,8 @@ INSERT INTO pdm_feature_counts_per_boundary (project_id, boundary, ts, label, am
  ON CONFLICT (project_id, boundary, ts, label) DO UPDATE SET amount=EXCLUDED.amount, len=EXCLUDED.len;
 
 -- Boundary rollup count
-INSERT INTO pdm_feature_counts_per_boundary (project_id, boundary, ts, label, amount, len)
-    SELECT :project_id as project_id, fb.boundary, d.ts, null as label, count(fc.osmid) as amount, sum(fc.geom_len) as len
+INSERT INTO pdm_feature_counts_per_boundary (project_id, boundary, ts, label, amount, len, area)
+    SELECT :project_id as project_id, fb.boundary, d.ts, null as label, count(fc.osmid) as amount, sum(fc.geom_len) as len, sum(fc.geom_area) as area
     FROM :changes_table fc
     JOIN :boundary_table fb ON fb.osmid=fc.osmid AND fb.version=fc.version
     JOIN pdm_features_counts_dates d

--- a/db/33_projects_contribs.sql
+++ b/db/33_projects_contribs.sql
@@ -4,7 +4,7 @@ ANALYSE pdm_user_names;
 ANALYSE :features_table;
 
 WITH unknown_users AS (
-  SELECT DISTINCT un.userid, un.username
+  SELECT DISTINCT f.userid, f.username
   FROM :features_table f
   LEFT JOIN pdm_user_names un ON un.userid=f.userid
   WHERE f.ts BETWEEN :start_date AND :end_date

--- a/db/opl2features.awk
+++ b/db/opl2features.awk
@@ -60,6 +60,7 @@ BEGIN {
     f = substr($1, 1, 1);          # Feature
     fi = substr($1, 2);            # Feature id
     v = substr($2, 2);             # Version
+    cs = substr($4, 2);            # Changeset
     d = substr($3, 2);             # Visibilité
     t = substr($5, 2);             # Timestamp
     w = substr($6, 2);             # User ID
@@ -145,6 +146,6 @@ BEGIN {
     }
 
     # Construction de la sortie CSV principale
-    printf "%s/%s,%s,%s,%s,%s,%s,%s,\"{%s}\",%s,%s\n",
-           features[f], fi, v, a, c, t, w, u, tagsjson, g, tagfilter_r >> output_main
+    printf "%s/%s,%s,%s,%s,%s,%s,%s,%s,\"{%s}\",%s,%s\n",
+           features[f], fi, v, cs, a, c, t, w, u, tagsjson, g, tagfilter_r >> output_main
 }

--- a/docs/QUERIES.md
+++ b/docs/QUERIES.md
@@ -1,0 +1,40 @@
+# Queries
+
+Here are a few queries to manipulate data associated to projects. These extend abilities of website with SQL client.
+
+### Evaluate changes
+
+Find features that get tags on a given version:
+
+```sql
+with lines_changes as (SELECT
+    osmid,
+    version,
+    tags,
+    lag(tags) OVER (PARTITION BY osmid ORDER BY version) AS tags_old,
+    geom_len
+  FROM pdm_features_lines_changes
+  WHERE osmid LIKE 'w%' AND action != 'delete'
+)
+SELECT osmid, version, tags_old, tags, (not tags_old ? 'circuits' and tags ? 'circuits') as circuit_add
+from lines_changes
+where tags is not null and not tags_old ? 'circuits' and tags ? 'circuits'
+```
+
+Find features that get tags on a given version and on a given boundary
+
+```sql
+with lines_changes as (SELECT
+    fc.osmid,
+    fc.version,
+    fc.tags,
+    lag(tags) OVER (PARTITION BY fc.osmid ORDER BY fc.version) AS tags_old,
+    fc.geom_len
+  FROM pdm_features_lines_changes fc
+  JOIN pdm_features_lines_boundary fb ON fb.osmid=fc.osmid AND fb.version=fc.version
+  WHERE fc.osmid LIKE 'w%' AND fc.action != 'delete' AND fb.boundary=120027
+)
+SELECT osmid, version, tags_old, tags, (not tags_old ? 'circuits' and tags ? 'circuits') as circuit_add
+from lines_changes
+where tags is not null and not tags_old ? 'circuits' and tags ? 'circuits'
+```

--- a/website/index.js
+++ b/website/index.js
@@ -527,7 +527,7 @@ app.get("/projects/:name/counts", (req, res) => {
       pool
         .query(
           `
-			SELECT ts, label, amount, len
+			SELECT ts, label, amount, len, area
 			FROM pdm_feature_counts
 			WHERE project_id = $1
 			ORDER BY ts ASC
@@ -542,8 +542,9 @@ app.get("/projects/:name/counts", (req, res) => {
             if (row.label == null) {
               acc[row.ts].amount = row.amount;
               acc[row.ts].length = row.len;
+              acc[row.ts].area = row.area;
             } else {
-              acc[row.ts].labels[row.label] = { amount: row.amount, length: row.len };
+              acc[row.ts].labels[row.label] = { amount: row.amount, length: row.len, area: row.area };
             }
             return acc;
           }, {});
@@ -600,7 +601,7 @@ app.get("/projects/:name/counts/boundary/:boundary", (req, res) => {
       pool
         .query(
           `
-			SELECT ts, label, amount, len
+			SELECT ts, label, amount, len, area
 			FROM pdm_feature_counts_per_boundary
 			WHERE project_id = $1 AND boundary = $2
 			ORDER BY ts ASC
@@ -615,8 +616,9 @@ app.get("/projects/:name/counts/boundary/:boundary", (req, res) => {
             if (row.label == null) {
               acc[row.ts].amount = row.amount;
               acc[row.ts].length = row.len;
+              acc[row.ts].area = row.area;
             } else {
-              acc[row.ts].labels[row.label] = { amount: row.amount, length: row.len };
+              acc[row.ts].labels[row.label] = { amount: row.amount, length: row.len, area: row.area };
             }
             return acc;
           }, {});


### PR DESCRIPTION
I propose following fixes and additional features
- Properly link nodes to ways with timestamp to select the nodes versions that exist at the date of each versions of ways
- Optimize versions linking
- Support changeset id in table feature
- Compute area of closed geometries

It will be necessary to rebuild every project as features table structure get another additional column for changeset id.

Apply following sql to update tables without uninstall:

```sql
alter table pdm_feature_counts add column area numeric not null default 0;
alter table pdm_feature_counts_per_boundary add column area numeric not null default 0;
```

Fix #361 

Wait for #357 