### PR TITLE
Complete mappers count with total amount

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -58,6 +58,7 @@ CREATE TABLE pdm_mapper_counts(
 	project_id int NOT NULL,
 	ts TIMESTAMP NOT NULL,
 	label varchar,
+	amount INT NOT NULL,
 	amount_1d INT NOT NULL,
 	amount_30d INT NOT NULL,
 
@@ -87,6 +88,7 @@ CREATE TABLE pdm_mapper_counts_per_boundary(
 	boundary BIGINT NOT NULL,
 	ts TIMESTAMP NOT NULL,
 	label varchar,
+	amount INT NOT NULL,
 	amount_1d INT NOT NULL,
 	amount_30d INT NOT NULL,
 

--- a/db/30_projects_update.js
+++ b/db/30_projects_update.js
@@ -241,7 +241,7 @@ else
 
     script += `
     echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Generate user contributions"
-    ${PSQL} -v project_id="${project.id}" -v features_table="pdm_features_${slug}" -v boundary_table="pdm_features_${slug}_boundary" -v labels_table="pdm_features_${slug}_labels"  -v start_date="'\${process_start_ts}'" -v end_date="'\${process_end_ts}'" -v dates_list="\$count_dates_list" -f "${__dirname}/33_projects_contribs.sql"
+    ${PSQL} -v project_id="${project.id}" -v features_table="pdm_features_${slug}" -v boundary_table="pdm_features_${slug}_boundary" -v labels_table="pdm_features_${slug}_labels"  -v start_date="'\${process_start_ts}'" -v end_date="'\${process_end_ts}'" -v project_start_date="'${project.start_date}'" -v dates_list="\$count_dates_list" -f "${__dirname}/33_projects_contribs.sql"
 
     if [ -f '${__dirname}/../projects/${project.name}/extract.sh' ]; then
         echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Extract script"

--- a/docs/DEVELOP.fr.md
+++ b/docs/DEVELOP.fr.md
@@ -130,9 +130,9 @@ Un projet peut ne pas avoir de date de fin, en utilisant `end_date: null` dans s
 - Cas 5 : un projet commencé récemment et se terminant dans le futur, régulièrement mis à jour et éligible à la mise à jour via les fichiers diffs.
 - Cas 6 : un projet non commencé, n'entrainant pour l'instant aucun traitement.
 
-### Dénombrement des objets
+### Dénombrements
 
-Le dénombrement des objets est opéré sur le journal des modifications de chaque objet sélectionné par le filtre du projet. Il est activé via le drapeau `statistics.count` dans la configuration du projet.  
+Le dénombrement des objets et des contributeurs est opéré sur le journal des modifications de chaque objet sélectionné par le filtre du projet. Il est activé via le drapeau `statistics.count` dans la configuration du projet.  
 Ces opérations nécessitent non seulement de connaître les dates d'existence de chaque version mais aussi l'adhérence de chacune au filtre du projet.  
 
 Il est possible de résumer les différentes configurations et leurs effets selon le schéma suivant :
@@ -146,8 +146,22 @@ Ces dates sont sélectionnées selon les hypothèses suivantes :
 
 En exécutant le script de calcul chaque jour, on obtiendra donc 364 valeurs à la fin d'une année complète de traitement.
 
+#### Dénombrement des objets
+
 Les dénombrements suivants sont réalisés de manière systématique :
 - Nombre d'objets existants et validant le filtre du projet à une date donnée
+- Longueur des chemins lorsque certains sont sélectionnés dans le filtre du projet
+- Surface des chemins fermés lorsque certains sont selectionnés dans le filtre du projet
+
+#### Dénombrement des contributeurs
+
+Les dénombrements de contributeurs sont réalisés de manière systématique :
+- Le nombre total de contributeurs aux versions sélectionnées par le filtre du projet
+- Le nombre de contributeurs étant intervenus sur des versions sélectionnées par le filtre du projet sur une fenêtre glissante de 24 heures
+- Le nombre de contributeurs étant intervenus sur des versions sélectionnées par le filtre du projet sur une fenêtre glissante de 30 jours
+
+Il convient d'indiquer que le nombre total de contributeurs ne doit pas être interprété comme le nombre d'utilisateurs ayant contribué depuis le début d'OSM sur le sujet concerné par le projet.  
+En effet, seules les versions actives au début du projet sont sélectionnées, masquant ainsi les contributeurs ayant contribué sur des objets complètement supprimés ou sur de précédentes version.
 
 ### Filtrer les objets
 

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -130,9 +130,9 @@ A project can be configured without end date, with `end_date: null`, to enable e
 - 5th case: A recently began project with an end date in the future, on which daily diffs updates are applicable until current date.
 - 6th case: A project to began in the future, which doesn't require any processing currently.
 
-### Features counts
+### Counting
 
-Features counts are done over change log fed by update and filtered by each project's own configuration. Counting features is enabled with the help of `statistics.count` flag.  
+Features and contributors counts are done over change log fed by update and filtered by each project's own configuration. Counting features is enabled with the help of `statistics.count` flag.  
 Computing suh statistics not only requires existence dates of each version but their validity regarding the project's filter as well.
 
 Each possible configuration can be summarised in this chart: 
@@ -145,8 +145,22 @@ Dates on which features are counted are selected by the processing script follow
 
 Running the count script each day will lead to 364 values at the end of a complete year.
 
-W currently support the following counts:
+#### Features counting
+
+The following counts are currently supported:
 - Total amount of features that valides the project's filter on a given date.
+- Ways length when some get selected by each project's filter
+- Area surface when some get selected by each project's filter
+
+#### Contributors counting
+
+The following counts are currently supported:
+- Total amount of contributors involved by features version in project's change log
+- Amount of contributors involved on features versions on a 24 hours time window
+- Amount of contributors involved on features versions on a 30 days time window
+
+The total amount of contributors should not be understood as the total amount of contributors involved since OSM beginning on project's perimeter.  
+Actually, we only select existing versions at the beginning of the project. It avoid contributors involved on completely deleted objects and previous versions.
 
 ### Filtering features
 


### PR DESCRIPTION
Following changes enable total mappers count, in addition to existing 1d and 30d mappers count for each project dates.
Additionnaly, the website is now plugged on pdm_mapper_counts table instead of leadboard to count people involved. 1d and 30d mappers counts are provided in API answer for future usage.

Following tables should be updated prior launching `update_projects` command:

```sql
alter table pdm_mapper_counts add column amount integer not null default 0;
alter table pdm_mapper_counts_per_boundary add column amount integer not null default 0;
```

Wait for #362 