### PR TITLE
Optimize update_changes and minor improvements

### DIFF
--- a/db/22_changes_init.sql
+++ b/db/22_changes_init.sql
@@ -23,22 +23,23 @@ CREATE TABLE :members_table (
 
 DROP MATERIALIZED VIEW IF EXISTS :changes_table;
 CREATE MATERIALIZED VIEW :changes_table as
-    SELECT
-    osmid,
-    version,
-	changeset,
-    ts as ts_start,
-	LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
-    userid,
-    tags,
-    action,
-    contrib,
-    tagsfilter,
-    geom,
-    CASE when geom is not null then St_Length(geom::geography) else 0 end as geom_len,
-	CASE when geom is not null and ST_IsClosed(geom) and St_geometrytype(geom) != 'ST_Point' then St_Area(ST_buildarea(geom)::geography) else 0 end as geom_area
-    FROM :features_table
-	WHERE action!='delete';
+	WITH changes as (SELECT
+		osmid,
+		version,
+		changeset,
+		ts as ts_start,
+		LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
+		userid,
+		tags,
+		action,
+		contrib,
+		tagsfilter,
+		geom,
+		CASE when geom is not null then St_Length(geom::geography) else 0 end as geom_len,
+		CASE when geom is not null and ST_IsClosed(geom) and St_geometrytype(geom) != 'ST_Point' then St_Area(ST_buildarea(geom)::geography) else 0 end as geom_area
+		FROM :features_table
+	)
+	SELECT * FROM changes where action!='delete';
 
 -- Associate a given feature/version to a label
 DROP TABLE IF EXISTS :labels_table CASCADE;

--- a/db/24_changes_boundary_partial.sql
+++ b/db/24_changes_boundary_partial.sql
@@ -1,0 +1,17 @@
+-- Insert unknown changes from :features_table filtered by :features_table_tmp and associate them with enclosing boundaries
+\timing
+WITH unknown AS (
+	SELECT distinct f.osmid AS osmid,
+	f.version as version,
+	b.osm_id AS boundary
+	FROM :features_table f
+	JOIN :features_table_tmp ft ON ft.osmid=f.osmid AND ft.version=f.version
+	JOIN pdm_boundary_subdivide b ON ST_Intersects(f.geom, b.geom)
+	LEFT JOIN :boundary_table fb ON fb.osmid=f.osmid AND fb.version=f.version AND fb.boundary=b.osm_id
+	WHERE fb.osmid IS NULL AND f.action!='delete' AND f.geom IS NOT NULL AND f.tagsfilter=true
+)
+INSERT INTO :boundary_table
+SELECT u.osmid AS osmid, u.version, u.boundary
+FROM unknown u;
+
+ANALYZE :boundary_table

--- a/db/26_changes_geom_rels.sql
+++ b/db/26_changes_geom_rels.sql
@@ -7,7 +7,7 @@ with members as (
     ts as ts_start,
     LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
     geom
-    FROM :features_table
+    FROM :features_perm_table
 	WHERE action != 'delete'
 ), list as (
 	select f.osmid osmid, f.version version, m.geom geom
@@ -22,4 +22,4 @@ with members as (
 	group by osmid, version
 	having NOT bool_or(geom is null)
 )
-update :features_table f set geom=rels.geom from rels where f.osmid=rels.osmid and f.version=rels.version;
+update :features_perm_table f set geom=rels.geom from rels where f.osmid=rels.osmid and f.version=rels.version;

--- a/db/26_changes_geom_ways.sql
+++ b/db/26_changes_geom_ways.sql
@@ -7,7 +7,7 @@ with nodes as (
     ts as ts_start,
     LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
     geom
-    FROM :features_table
+    FROM :features_perm_table
 	WHERE osmid like 'n%' and action != 'delete'
 ), list as (
 	select f.osmid osmid, f.version version, n.geom geom
@@ -21,4 +21,4 @@ with nodes as (
 	from list
 	group by osmid, version
 )
-update :features_table f set geom=ways.geom from ways where f.osmid=ways.osmid and f.version=ways.version;
+update :features_perm_table f set geom=ways.geom from ways where f.osmid=ways.osmid and f.version=ways.version;


### PR DESCRIPTION
I propose the following improvements to speed up the projects processing:

- Better rely on partial features table when updating (for boundaries and geom rebuild), preventing to process millions of existing and unchanged features
- Only rebuild relation geom when relations are selected in the filter
- Ability to keep temp files, useful when debugging and expect to reuse the same files several times
- Fixing missing end dates in _changes views

No gain during initing but significant improvements when updating.worldwide projects:
- Boundaries assignment is reduced 10 times (even more for power towers 2286s => 77s)
- Ways geometries rebuild is reduced by 5 times

That may not be as significant on national projects but it will surely helps anyway.

Materialiazed views pdm_features_..._changes need to be recreated:
```sql
DROP MATERIALIZED VIEW IF EXISTS pdm_features_..._changes;
CREATE MATERIALIZED VIEW pdm_features_..._changes as
	WITH changes as (SELECT
		osmid,
		version,
		changeset,
		ts as ts_start,
		LEAD(ts) OVER (PARTITION BY osmid ORDER BY version) AS ts_end,
		userid,
		tags,
		action,
		contrib,
		tagsfilter,
		geom,
		CASE when geom is not null then St_Length(geom::geography) else 0 end as geom_len,
		CASE when geom is not null and ST_IsClosed(geom) and St_geometrytype(geom) != 'ST_Point' then St_Area(ST_buildarea(geom)::geography) else 0 end as geom_area
		FROM pdm_features_...
	)
	SELECT * FROM changes where action!='delete';
```

**Replace ... with each project's slug**

And recount every project:
```bash
docker run -d --name=pdm_init -v /data/files/pdm:/data/files/pdm -e DB_URL=postgres://user:passwd@db:5432/db pdm/server:latest update_projects init
```