### PR TITLE
Introduce missing members retrieval with Overpass

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,7 @@
   "OSM_USER": "user",
   "OSM_PASS": "pass",
   "OSM_CLIENT_ID": "id",
+  "OVERPASS_URL": "https://overpass-api.de/api/interpreter",
   "OSMOSE_URL": "https://osmose.openstreetmap.fr",
   "NOMINATIM_URL": "https://nominatim.openstreetmap.org",
   "MAPILLARY_URL": "https://www.mapillary.com",

--- a/db/22_changes_index.sql
+++ b/db/22_changes_index.sql
@@ -8,6 +8,8 @@ CREATE INDEX ON :features_table (userid);
 CREATE INDEX ON :features_table using gist(geom);
 CREATE INDEX ON :features_table using gin(tags);
 
+CREATE INDEX ON :update_table using gist(geom);
+
 CREATE INDEX ON :members_table (osmid, version, memberid, pos);
 CREATE INDEX ON :members_table (osmid, version);
 CREATE INDEX ON :members_table (memberid);

--- a/db/22_changes_init.sql
+++ b/db/22_changes_init.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS :features_table CASCADE;
+DROP TABLE IF EXISTS :update_table CASCADE;
 CREATE TABLE :features_table (
 	osmid VARCHAR NOT NULL,
 	version INT NOT NULL,
@@ -11,6 +12,7 @@ CREATE TABLE :features_table (
 	contrib VARCHAR DEFAULT NULL,
 	tagsfilter boolean
 );
+CREATE TABLE :update_table (like :features_table);
 
 DROP TABLE IF EXISTS :members_table CASCADE;
 CREATE TABLE :members_table (

--- a/db/23_changes_populate.sql
+++ b/db/23_changes_populate.sql
@@ -1,12 +1,12 @@
 -- Insert unknown changes in main table
 \timing
-CREATE INDEX ON :features_table_tmp using btree(osmid, version);
+CREATE INDEX ON :update_table using btree(osmid, version);
 
 WITH unknown AS (
-	SELECT tmp.*
-	FROM :features_table_tmp tmp
-	LEFT JOIN :features_table pc ON pc.osmid=tmp.osmid AND pc.version=tmp.version
-	WHERE pc.osmid IS NULL
+	SELECT fu.*
+	FROM :update_table fu
+	LEFT JOIN :features_table f ON f.osmid=fu.osmid AND f.version=fu.version
+	WHERE f.osmid IS NULL
 )
 INSERT INTO :features_table
 SELECT u.*

--- a/db/24_changes_boundary_partial.sql
+++ b/db/24_changes_boundary_partial.sql
@@ -5,7 +5,7 @@ WITH unknown AS (
 	f.version as version,
 	b.osm_id AS boundary
 	FROM :features_table f
-	JOIN :features_table_tmp ft ON ft.osmid=f.osmid AND ft.version=f.version
+	JOIN :update_table fu ON fu.osmid=f.osmid AND fu.version=f.version
 	JOIN pdm_boundary_subdivide b ON ST_Intersects(f.geom, b.geom)
 	LEFT JOIN :boundary_table fb ON fb.osmid=f.osmid AND fb.version=f.version AND fb.boundary=b.osm_id
 	WHERE fb.osmid IS NULL AND f.action!='delete' AND f.geom IS NOT NULL AND f.tagsfilter=true

--- a/db/25_changes_members_missing.sql
+++ b/db/25_changes_members_missing.sql
@@ -1,0 +1,17 @@
+-- Insert unknown members in table
+WITH features as (
+  select osmid, version from :features_table
+  union
+  select osmid, version from :features_table_update
+), unknown as (
+  select distinct m.memberid
+  from :members_table m 
+  left join features f ON f.osmid=m.memberid
+  where f.version is null
+) 
+
+select 
+  case when count(distinct case when memberid like 'node%' then memberid end) > 0 then concat('node(id:', array_to_string(array_agg(distinct case when memberid like 'node%' then replace(memberid, 'node/','') end), ','),');') end as nodes,
+  case when count(distinct case when memberid like 'way%' then memberid end) > 0 then concat('way(id:', array_to_string(array_agg(distinct case when memberid like 'way%' then replace(memberid, 'way/','') end), ','),');') end as ways,
+  case when count(distinct case when memberid like 'relation%' then memberid end) > 0 then concat('relation(id:', array_to_string(array_agg(distinct case when memberid like 'relation%' then replace(memberid, 'relation/','') end), ','),');') end as relation
+from unknown;

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -57,6 +57,7 @@ The general configuration of the tool is to be filled in `config.json`. There is
 - `OSM_URL`: OpenStreetMap instance to use (example `https://www.openstreetmap.org`)
 - `OSM_API_URL` : API OpenStreetMap instance to use (example `https://www.api.openstreetmap.org`)
 - `JOSM_REMOTE_URL`: address of the JOSM server to reach (example `http://localhost:8111`)
+- `OVERPASS_URL`: URL towards the interpreter of an Overpass-API instance to be used for missing members retrieval
 - `OSMOSE_URL`: Osmose instance to use (example `https://osmose.openstreetmap.fr`)
 - `NOMINATIM_URL`: instance of Nominatim to use (example `https://nominatim.openstreetmap.org`)
 - `MAPILLARY_URL`: Mapillary instance to use (example `https://www.mapillary.com`)
@@ -202,6 +203,17 @@ psql -d postgresql://... -v features_table="pdm_features_project" -v labels_tabl
 ```
 
 Then, the `update_projects` should be inited again to propagate the new labels into counts and KPI.
+
+#### Missing members
+As explained upside, Podoma uses the daily diffs to keep projects updated. Those diffs files only contain modified features and even if a way or a relation may be included in it, none of their members will be mentioned is they hadn't been edited themselves.  
+It can finally causes issues when some unknown features in the database are rferenced by ways or relations.
+
+Podoma only keeps track of useful features for projects, it needs to check after each update if unknown features should be retrieved.  
+Overpass API is used by projects which require to get such missing members. A single query is sent to retrieve all nodes, ways, relations and their descendents to take care of recursivity. Thus a query covering 10 missing features can lead to a greater amount of results.
+
+Those features are then processed the same way than the ones we got from daily diffs files. This process complete the temporary files without any particularism.
+
+To disable this retrieval, just set a null `OVERPASS_URL` in your Podoma configuration file.
 
 ### Disable imposm3 usage
 


### PR DESCRIPTION
As described in #391, daily diffs doesn't include referenced features, ways nodes and relations members in particular.

This PR intends to retrieve members that may be missing after a daily diff process.
So it is restricted on the update mode, as the OSH always provides everything referenced during init.

The process is provided with curl connecting to Overpass. It will try 3 times to pass a single query whatever the amount of feature to retrieve is, which may cause issues.
I will test that on worldwide projects to see how able it is.
Some improvements may be required prior to merge to handle errors or Overpass disruptions.

This PR also introduce another permanent table for each project which contains updated features on the last update run.
It is necessary to create them with following command:

```sql
CREATE TABLE pdm_features_...slug..._update (like pdm_features_...slug...);
```

A supplementary argument should be added to the configuration to reach Overpass. Members retrieval won't be activated if missing.

```json
  "OVERPASS_URL": "https://overpass-api.de/api/interpreter",
```

This saves us from maintaining updated a database for the whole perimeter covered, not to mention worldwide.

Fix #391 