### PR TITLE
Minor fixes in projects processing and counts

### DIFF
--- a/db/22_changes_init_linear.sql
+++ b/db/22_changes_init_linear.sql
@@ -41,7 +41,7 @@ CREATE MATERIALIZED VIEW :changes_table as
             else 0
         end as geom_len,
         case
-            when geom is not null and ST_IsClosed(geom) and St_geometrytype(geom) != 'ST_Point' then St_Area(ST_buildarea(geom)::geography)
+            when geom is not null and ST_IsClosed(geom) and St_geometrytype(geom) != 'ST_Point' then coalesce(St_Area(ST_buildarea(geom)::geography),0)
             else 0
         end as geom_area,
         case

--- a/db/22_changes_init_nodes.sql
+++ b/db/22_changes_init_nodes.sql
@@ -14,6 +14,7 @@ CREATE MATERIALIZED VIEW :changes_table as
         contrib,
         geom
         FROM :features_table
+        WINDOW wbkwd AS (PARTITION BY osmid ORDER BY version desc)
         )
     SELECT
         osmid,

--- a/db/33_projects_contribs.sql
+++ b/db/33_projects_contribs.sql
@@ -83,9 +83,9 @@ INSERT INTO pdm_user_contribs(project_id, userid, ts, label, contribution, amoun
         end) as amount_delta,
       SUM(cc.geom_len_delta) as len_delta,
       SUM(cc.geom_area_delta) AS area_delta,
-      SUM(cc.nb * pp.points) AS points
+      SUM(cc.nb * coalesce(pp.points,0)) AS points
     FROM contributions cc
-    LEFT JOIN pdm_projects_points pp ON cc.contrib=pp.contrib AND cc.label=pp.label AND pp.project_id=:project_id
+    LEFT JOIN pdm_projects_points pp ON cc.contrib=pp.contrib AND coalesce(cc.label,'global')=coalesce(pp.label,'global') AND pp.project_id=:project_id
     GROUP BY project_id, cc.ts, cc.userid, cc.label, cc.contrib;
 
 -- Main labels count


### PR DESCRIPTION
Here are a few fixes after updating one of my instances.

Theses problems are not supposed to happen, but due to lack of unit tests, we can only spot them with current instances operation.

* Missing update table name in SQL init for all projects
* Added test on amounts to be added projects / points / teams to avoid useless SQL errors in case of nothing added
* Improve support of invalid geometries for area computation
* Missing window in nodes changes view
* Invalid join on NULL values for points attribution