### PR TITLE
Improve boundaries stats tiles computation

### DIFF
--- a/db/00_init.sql
+++ b/db/00_init.sql
@@ -50,10 +50,14 @@ CREATE TABLE pdm_user_contribs(
 CREATE INDEX ON pdm_user_contribs(project_id);
 CREATE INDEX ON pdm_user_contribs(userid);
 
--- User badges
-DROP TABLE IF EXISTS pdm_user_badges;
-
 -- Overall counts
+CREATE TABLE pdm_counts_dates (
+	project_id int NOT NULL,
+	ts timestamp NOT NULL,
+	ts_past timestamp NOT NULL
+);
+CREATE INDEX ON pdm_counts_dates using btree(project_id, ts);
+
 CREATE TABLE pdm_feature_counts(
 	project_id int NOT NULL,
 	ts TIMESTAMP NOT NULL,

--- a/db/32_projects_counts.sql
+++ b/db/32_projects_counts.sql
@@ -3,6 +3,7 @@
 ANALYSE :changes_table;
 ANALYSE :labels_table;
 
+DELETE FROM pdm_counts_dates WHERE project_id=:project_id AND ts BETWEEN :start_date AND :end_date;
 DELETE FROM pdm_feature_counts WHERE project_id=:project_id AND ts BETWEEN :start_date AND :end_date;
 DELETE FROM pdm_feature_counts_per_boundary WHERE project_id=:project_id AND ts BETWEEN :start_date AND :end_date;
 

--- a/db/34_projects_init.sql
+++ b/db/34_projects_init.sql
@@ -1,3 +1,4 @@
+DELETE FROM pdm_counts_dates WHERE project_id=:project_id;
 DELETE FROM pdm_feature_counts WHERE project_id=:project_id;
 DELETE FROM pdm_feature_counts_per_boundary WHERE project_id=:project_id;
 DELETE FROM pdm_mapper_counts WHERE project_id=:project_id;

--- a/db/90_uninstall.sql
+++ b/db/90_uninstall.sql
@@ -5,10 +5,10 @@ DROP TABLE IF EXISTS pdm_user_names CASCADE;
 DROP TABLE IF EXISTS pdm_user_contribs CASCADE;
 
 -- User badges
-DROP TABLE IF EXISTS pdm_user_badges CASCADE;
 DROP FUNCTION IF EXISTS pdm_get_badges CASCADE;
 
 -- Features counts
+DROP TABLE IF EXISTS pdm_counts_dates CASCADE;
 DROP TABLE IF EXISTS pdm_feature_counts CASCADE;
 DROP TABLE IF EXISTS pdm_feature_counts_per_boundary CASCADE;
 


### PR DESCRIPTION
This PR improves the stats tiles computation for boundaries.
Fixes #401 

Before:
<img width="658" height="342" alt="Image" src="https://github.com/user-attachments/assets/54010855-cf4a-4e27-ad95-7a6625a18947" />

After:
<img width="550" height="333" alt="image" src="https://github.com/user-attachments/assets/a1f37aef-efd5-4b8e-a5b4-1c6e29d0676d" />

Every boundaries now have the same dates with possible filling 0 if no count is available when producing the tile.

It is necessary to keep track of processed dates to support projects that may begin with 0 existing feature in OSM.

To upgrade, create the following sql tables and views:
```sql
CREATE TABLE pdm_counts_dates (
	project_id int NOT NULL,
	ts timestamp NOT NULL,
	ts_past timestamp NOT NULL
);
CREATE INDEX ON pdm_counts_dates using btree(project_id, ts);

DROP MATERIALIZED VIEW pdm_boundary_tiles;

CREATE MATERIALIZED VIEW pdm_boundary_tiles AS
WITH boundaries as (
	SELECT DISTINCT fb.project_id, fb.boundary, b.name, b.admin_level, b.centre as geom
	FROM pdm_feature_counts_per_boundary fb
	JOIN pdm_boundary b ON b.osm_id=fb.boundary
),
stats as (
	SELECT 
		b.boundary,
		d.project_id,
		NULL as label,
		COALESCE(fb.amount, 0) as amount,
		d.ts,
		b.name,
		b.admin_level,
		b.geom,
		COALESCE(last_value(fb.amount) over project_window, 0) - COALESCE(first_value(fb.amount) over project_window, 0) as nb
	FROM pdm_counts_dates d
	JOIN boundaries b ON b.project_id=d.project_id
	LEFT JOIN pdm_feature_counts_per_boundary fb ON fb.project_id=d.project_id AND fb.ts=d.ts AND fb.boundary=b.boundary
	WHERE fb.label IS NULL
	WINDOW project_window AS (PARTITION BY d.project_id, b.boundary ORDER BY d.ts ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
)
SELECT
	s.boundary as id,
	s.boundary as boundary,
	s.project_id,
	s.label,
	s.name,
	s.admin_level,
	s.geom,
	json_object(array_agg(s.ts::date::text), array_agg(s.amount::text)) AS stats,
	s.nb
FROM stats s
GROUP BY s.project_id, s.label, s.boundary, s.nb, s.name, s.admin_level, s.geom;

CREATE INDEX pdm_boundary_tiles_project_idx ON pdm_boundary_tiles(project_id);
CREATE INDEX pdm_boundary_tiles_geom_idx ON pdm_boundary_tiles USING GIST(geom);
```