### PR TITLE
Prevent anonymous edits to be listed in userslists

### DIFF
--- a/db/opl2features.awk
+++ b/db/opl2features.awk
@@ -157,7 +157,7 @@ BEGIN {
     }
 
     # Construction de la sortie contributeurs
-    if (length(output_users) > 0){
+    if (length(output_users) > 0 && length(u) > 0){
         printf "%s,%s\n",
            u, w >> output_users
     }


### PR DESCRIPTION
This change fixes #405

It prevents anonymous edits to be listed in user list and violate not null constraint in `pdm_user_names`

@Danysan1 I think you have the best setup to test it as I don't have any project that currently involves those features.
The patch is not complex.

We could merge once properly validated (and possibly include other fixes depending on your process).