### PR TITLE
Fix i18n + add pgadmin + style origin header

### DIFF
--- a/db/10_features_update.js
+++ b/db/10_features_update.js
@@ -152,6 +152,9 @@ mode="$1"
 if [[ -z "$mode" ]]; then
 	mode="update"
 fi
+
+psql -d ${process.env.DB_URL} -c 'SELECT COUNT(*) FROM pdm_compare_exclusions' # If an error is thrown here, the DB still needs to be initialized with the install script or directly with db/01_setup_schema.sql
+
 `;
 
 if (IMPOSM_ENABLED && CONFIG.hasOwnProperty("OSM_PBF_URL")){

--- a/db/pgadmin_init.json
+++ b/db/pgadmin_init.json
@@ -1,0 +1,13 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "Podoma PostGIS",
+            "Group": "Servers",
+            "Port": 5432,
+            "Username": "postgres",
+            "Host": "pgsqldb",
+            "SSLMode": "prefer",
+            "MaintenanceDB": "postgres"
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
     environment:
       - POSTGRES_DB=pdm
       - POSTGRES_PASSWORD=pgpassword
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 10s
+      timeout: 1s
+      retries: 5
       
   pdm:
     image: pdm/server:latest
@@ -43,10 +48,34 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:pgpassword@pgsqldb:5432/pdm
 
+  pgadmin:
+    image: dpage/pgadmin4:9.12
+    restart: unless-stopped
+    profiles:
+      - pgadmin
+    depends_on:
+      - pgsqldb
+    networks:
+      - oim-internal
+    ports:
+      - "8000:80"
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+      - ./db/pgadmin_init.json:/pgadmin4/servers.json
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "app@app.app"
+      PGADMIN_DEFAULT_PASSWORD: "app"
+    healthcheck:
+      test: ["CMD", "wget", "-O", "-", "http://localhost:80/misc/ping"]
+      interval: 20s
+      timeout: 1s
+      retries: 5
+
 volumes:
   db-data:
   pdm-data:
   workdir:
+  pgadmin-data:
 
 networks:
   oim-internal:

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -127,7 +127,7 @@ Podoma allows whether daily update and complete rebuild of a terminated project 
 A project can be configured without end date, with `end_date: null`, to enable endless updates.
 
 ![Supported projects timelines](./projects_process.svg)
-- 1st case: An old project with an end date which completely fits in the OSH file availbility. It doesn't need updates but can be reinit on demand.
+- 1st case: An old project with an end date which completely fits in the OSH file availability. It doesn't need updates but can be reinit on demand.
 - 2nd case: An old project without end date, too old to be updated with diffs files and requires to be reinited to reach current date.
 - 3rd case: An old project without end date, recently updated and for which daily diffs update are applicable until current date.
 - 4th case: An old project with an end date in the future, on which daily diffs updates are applicable until current date.
@@ -145,13 +145,13 @@ Podoma makes use of Osmium and Imposm to filter necessary features according to 
 
 Perimeter filter must be selective enough to deal with reasonable amount of features. It must be wide enough to take care of several tagging practices in OSM community for the topic that matters. It is then recommended to focus on main tags here and use labels to get in details about classification, see below.
 
-Documented syntax of filters is available in [Osmium documentation online](https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html). However, due to the need to apply those filters at severel steps of the processing, including outside of Osmium logic, filters that would use `!=` operator aren't currently supported.
+Documented syntax of filters is available in [Osmium documentation online](https://docs.osmcode.org/osmium/latest/osmium-tags-filter.html). However, due to the need to apply those filters at several steps of the processing, including outside of Osmium logic, filters that would use `!=` operator aren't currently supported.
 
 #### Labelling
-As to complete filtering functionnality, Podoma supports the assignment of labels to each version of features depending on their tags.  
+As to complete filtering functionality, Podoma supports the assignment of labels to each version of features depending on their tags.  
 Each version can be assigned with 0, 1 or more labels. Then each label can cover part or the whole project.
 
-Labels are then used in counts and KPI to distinguishe several population fo features inside the same project. It it then recommended to consider a wide project filter to include even imperfect features and not only the perfect ones and then separate them with labels. Consumers will then not only spot the population covered by the project but the ones that should be completed to be included in it as well. 
+Labels are then used in counts and KPI to distinguish several population fo features inside the same project. It it then recommended to consider a wide project filter to include even imperfect features and not only the perfect ones and then separate them with labels. Consumers will then not only spot the population covered by the project but the ones that should be completed to be included in it as well. 
 
 The syntax that is used to define labels conforms to [Postgresql's SQL/JSON](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-SQLJSON-PATH) which supports types. You can use the following example to define your own labels:
 
@@ -178,7 +178,7 @@ Then, the `update_projects` should be inited again to propagate the new labels i
 
 #### Missing members
 As explained upside, Podoma uses the daily diffs to keep projects updated. Those diffs files only contain modified features and even if a way or a relation may be included in it, none of their members will be mentioned is they hadn't been edited themselves.  
-It can finally causes issues when some unknown features in the database are rferenced by ways or relations.
+It can finally causes issues when some unknown features in the database are referenced by ways or relations.
 
 Podoma only keeps track of useful features for projects, it needs to check after each update if unknown features should be retrieved.  
 Overpass API is used by projects which require to get such missing members. A single query is sent to retrieve all nodes, ways, relations and their descendents to take care of recursivity. Thus a query covering 10 missing features can lead to a greater amount of results.
@@ -219,13 +219,13 @@ Some features may have a complex timeline, gaining and losing tags and validity 
 
 Dates on which features are counted are selected by the processing script following a precise logic. The span on which the script is used impacts the way those dates are selected. Starting from the current date, we keep the following:
 - Each day at midnight until last count update or 1st day of the current month
-- First day of each month until the last count update or begining of the project
+- First day of each month until the last count update or beginning of the project
 
 Running the count script each day will lead to 364 values at the end of a complete year.
 
 Project statistics are made by `./db/31_projects_update_tmp.sh` script. This script fills `pdm_feature_counts` SQL table with missing daily data according to last OSH file timestamp and current day.
 
-It is possible to force full recount for a project by deleting OSH timestamp file, retreive again PBF/PBH files and launch again the script:
+It is possible to force full recount for a project by deleting OSH timestamp file, retrieve again PBF/PBH files and launch again the script:
 
 ```bash
 rm ${WORK_DIR}/osh_timestamp
@@ -250,7 +250,7 @@ Following counts are done over a time frame between two dates of the timeline up
 - The actual surface contributed by the team, as the sum of surface delta of each version linked to each team member
 
 Figure upside tries to explain how two teams contributions are counted over a way edited 5 times by 3 différent mappers.  
-Currenty, contributions that removes feature out of a label can't be counted. As a result for each label, only positive contributions are part of the total.
+Currently, contributions that removes feature out of a label can't be counted. As a result for each label, only positive contributions are part of the total.
 
 #### Contributors counting
 
@@ -531,11 +531,11 @@ Icon select fields allow simple selecting of several similar attributes, for exa
 ## Build
 
 Once PDM has been properly configured, you should choose between Docker or standalone to build it.
-Refers to Database section in run chapter to make Podoma fully runable.
+Refers to Database section in run chapter to make Podoma fully runnable.
 
 ### git submodules
 
-Podoma relies on some git submodules. Please mind using the following to retreive them prior to build
+Podoma relies on some git submodules. Please mind using the following to retrieve them prior to build
 
 ```sh
 git submodule init

--- a/website/index.js
+++ b/website/index.js
@@ -519,14 +519,14 @@ app.get("/projects/:name/stats", (req, res) => {
             results.rows.length > 0
               ? [
                   {
-                    label: "Ouvertes",
+                    label: i18n.__("notes opened"),
                     data: results.rows.map((r) => ({ x: r.ts, y: r.open })),
                     fill: false,
                     borderColor: "#c62828",
                     lineTension: 0,
                   },
                   {
-                    label: "Résolues",
+                    label: i18n.__("closed"),
                     data: results.rows.map((r) => ({ x: r.ts, y: r.closed })),
                     fill: false,
                     borderColor: "#388E3C",
@@ -568,7 +568,7 @@ app.get("/projects/:name/stats", (req, res) => {
         .then((results) => ({
           chart: [
             {
-              label: "Nombre dans OSM",
+              label: i18n.__("Count in OSM"),
               data: results.rows.map((r) => ({ x: r.ts, y: r.amount })),
               fill: false,
               borderColor: "#388E3C",
@@ -677,7 +677,7 @@ app.get("/projects/:name/stats", (req, res) => {
             labels: d.map((r) => r.k),
             datasets: [
               {
-                label: "Nombre d'objets pour la clé",
+                label: i18n.__("Number of objects per key"),
                 data: d.map((r) => r.amount),
                 fill: false,
                 backgroundColor: "#1E88E5",

--- a/website/index.js
+++ b/website/index.js
@@ -526,7 +526,7 @@ app.get("/projects/:name/stats", (req, res) => {
                     lineTension: 0,
                   },
                   {
-                    label: res.__("closed"),
+                    label: res.__("resolved"),
                     data: results.rows.map((r) => ({ x: r.ts, y: r.closed })),
                     fill: false,
                     borderColor: "#388E3C",

--- a/website/index.js
+++ b/website/index.js
@@ -519,14 +519,14 @@ app.get("/projects/:name/stats", (req, res) => {
             results.rows.length > 0
               ? [
                   {
-                    label: i18n.__("notes opened"),
+                    label: res.__("notes opened"),
                     data: results.rows.map((r) => ({ x: r.ts, y: r.open })),
                     fill: false,
                     borderColor: "#c62828",
                     lineTension: 0,
                   },
                   {
-                    label: i18n.__("closed"),
+                    label: res.__("closed"),
                     data: results.rows.map((r) => ({ x: r.ts, y: r.closed })),
                     fill: false,
                     borderColor: "#388E3C",
@@ -568,7 +568,7 @@ app.get("/projects/:name/stats", (req, res) => {
         .then((results) => ({
           chart: [
             {
-              label: i18n.__("Count in OSM"),
+              label: res.__("Count in OSM"),
               data: results.rows.map((r) => ({ x: r.ts, y: r.amount })),
               fill: false,
               borderColor: "#388E3C",
@@ -677,7 +677,7 @@ app.get("/projects/:name/stats", (req, res) => {
             labels: d.map((r) => r.k),
             datasets: [
               {
-                label: i18n.__("Number of objects per key"),
+                label: res.__("Number of objects per key"),
                 data: d.map((r) => r.amount),
                 fill: false,
                 backgroundColor: "#1E88E5",

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -101,6 +101,8 @@
 	"Closed": "Closed",
 	"Re-opened": "Re-opened",
 	"Commented": "Commented",
+	"notes opened": "notes opened",
+	"resolved": "resolved",
 	"You must be logged in to set the note as resolved.": "You must be logged in to set the note as resolved.",
 	"💬 Comment": "💬 Comment",
 	"Contribute to the discussion on this note": "Contribute to the discussion on this note",
@@ -134,5 +136,10 @@
 	"participations": "participations",
 	"Currently: %s prioritary projects": "Currently: %s prioritary projects",
 	"Currently: %s": "Currently: %s",
-	"Discuss": "Discuss"
+	"Discuss": "Discuss",
+	"Count in OSM": "Count in OSM",
+	"Number of objects per key": "Number of objects per key",
+	"%s added": "%s added",
+	"%s total in OSM": "%s total in OSM",
+	"Thank you!": "Thank you!"
 }

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -141,5 +141,7 @@
 	"Number of objects per key": "Number of objects per key",
 	"%s added": "%s added",
 	"%s total in OSM": "%s total in OSM",
-	"Thank you!": "Thank you!"
+	"Thank you!": "Thank you!",
+	"Thank you all!": "Thank you all!",
+	"Thanks to all the contributors for making this project a success. Without all of you, OpenStreetMap would be nothing!": "Thanks to all the contributors for making this project a success. Without all of you, OpenStreetMap would be nothing!"
 }

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -141,5 +141,7 @@
 	"Number of objects per key": "Nombre d'objets pour la clé",
 	"%s added": "%s ajoutés",
 	"%s total in OSM": "%s au total dans OSM",
-	"Thank you!": "Merci !"
+	"Thank you!": "Merci!",
+	"Thank you all!": "Merci à toutes et tous!",
+	"Thanks to all the contributors for making this project a success. Without all of you, OpenStreetMap would be nothing!": "Merci à l'ensemble des personnes contributrices pour la réussite de ce projet. Sans vous, OpenStreetMap ne serait rien!"
 }

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -101,6 +101,8 @@
 	"Closed": "Fermé",
 	"Re-opened": "Ré-ouvert",
 	"Commented": "Commenté",
+	"notes opened": "notes ouvertes",
+	"resolved": "résolues",
 	"You must be logged in to set the note as resolved.": "Vous devez être connecté pour marquer la note comme résolue.",
 	"💬 Comment": "💬 Commenter",
 	"Contribute to the discussion on this note": "Participer à la discussion sur cette note",
@@ -134,5 +136,10 @@
 	"participations": "participations",
 	"Currently: %s prioritary projects": "En ce moment : %s projets prioritaires",
 	"Currently: %s": "En ce moment : %s",
-	"Discuss": "Discuter"
+	"Discuss": "Discuter",
+	"Count in OSM": "Nombre dans OSM",
+	"Number of objects per key": "Nombre d'objets pour la clé",
+	"%s added": "%s ajoutés",
+	"%s total in OSM": "%s au total dans OSM",
+	"Thank you!": "Merci !"
 }

--- a/website/locales/it.json
+++ b/website/locales/it.json
@@ -101,6 +101,8 @@
 	"Closed": "Chiusa",
 	"Re-opened": "Riaperta",
 	"Commented": "Commentata",
+	"notes opened": "note aperte",
+	"resolved": "risolte",
 	"You must be logged in to set the note as resolved.": "Devi aver effettuato l'accesso per contrassegnare la nota come risolta.",
 	"💬 Comment": "💬 Commento",
 	"Contribute to the discussion on this note": "Contribuisci alla discussione su questa nota",
@@ -134,5 +136,10 @@
 	"participations": "partecipazioni",
 	"Currently: %s prioritary projects": "In corso: %s progetti prioritari",
 	"Currently: %s": "In corso: %s",
-	"Discuss": "Discussione"
+	"Discuss": "Discussione",
+	"Count in OSM": "Conteggio in OSM",
+	"Number of objects per key": "Numero di oggetti per chiave",
+	"%s added": "%s aggiunti",
+	"%s total in OSM": "%s totali in OSM",
+	"Thank you!": "Grazie!"
 }

--- a/website/locales/it.json
+++ b/website/locales/it.json
@@ -141,5 +141,7 @@
 	"Number of objects per key": "Numero di oggetti per chiave",
 	"%s added": "%s aggiunti",
 	"%s total in OSM": "%s totali in OSM",
-	"Thank you!": "Grazie!"
+	"Thank you!": "Grazie!",
+	"Thank you all!": "Grazie a tutti!",
+	"Thanks to all the contributors for making this project a success. Without all of you, OpenStreetMap would be nothing!": "Grazie a tutti i contributori per aver reso questo progetto un successo! Senza di voi OpenStreetMap non sarebbe quello che è!"
 }

--- a/website/templates/components/stats.pug
+++ b/website/templates/components/stats.pug
@@ -84,8 +84,8 @@ script.
 				blocks.appendChild(b);
 			};
 
-			if(res.added) { addBlock(numberFormat.format(res.added), "#{title.toLowerCase()} ajoutés"); }
-			if(res.count) { addBlock(numberFormat.format(res.count), "#{title.toLowerCase()} au total dans OSM"); }
+			if(res.added) { addBlock(numberFormat.format(res.added), "#{__('%s added', title.toLowerCase())}"); }
+			if(res.count) { addBlock(numberFormat.format(res.count), "#{__('%s total in OSM', title.toLowerCase())}"); }
 			if(res.tasksSolved !== undefined) { addBlock(numberFormat.format(res.tasksSolved), "#{statistics.osmose_tasks}"); }
 			addBlock(numberFormat.format(res.nbContributors), "#{__("contributors")}");
 
@@ -186,7 +186,7 @@ script.
 				if(#{isRecentPast || "false"}) {
 					const wordCloudDom = document.getElementById("word-cloud");
 					wordCloudDom.classList.remove("d-none");
-					wordCloud.unshift(["Merci !", 50]);
+					wordCloud.unshift(["#{__("Thank you!")}", 50]);
 					createWordCloud(wordCloudDom, wordCloud);
 				}
 			}
@@ -225,7 +225,7 @@ script.
 
 			// Notes count + chart
 			if(res.chartNotes) {
-				addBlock(numberFormat.format(res.openedNotes), `notes ouvertes (${res.statClosedNotes} résolues)`);
+				addBlock(numberFormat.format(res.openedNotes),`#{__("notes opened")} (${res.statClosedNotes} #{__("solved")})`);
 
 				const myChart = new Chart(document.getElementById("stats-chart-notes").getContext("2d"), {
 					type: "line",

--- a/website/templates/components/stats.pug
+++ b/website/templates/components/stats.pug
@@ -225,7 +225,7 @@ script.
 
 			// Notes count + chart
 			if(res.chartNotes) {
-				addBlock(numberFormat.format(res.openedNotes),`#{__("notes opened")} (${res.statClosedNotes} #{__("solved")})`);
+				addBlock(numberFormat.format(res.openedNotes),`#{__("notes opened")} (${res.statClosedNotes} #{__("resolved")})`);
 
 				const myChart = new Chart(document.getElementById("stats-chart-notes").getContext("2d"), {
 					type: "line",

--- a/website/templates/pages/project.pug
+++ b/website/templates/pages/project.pug
@@ -158,4 +158,4 @@ block content
 									div.media-body.align-self-center
 										a.text-decoration-none(href=`/projects/${proj.name}`)
 											| #{proj.title}
-											span.text-muted.d-block= new Date(proj.month).toLocaleString('fr-FR', { month: 'long', year: 'numeric' })
+											span.text-muted.d-block= new Date(proj.month).toLocaleString(getLocale(), { month: 'long', year: 'numeric' })

--- a/website/utils.js
+++ b/website/utils.js
@@ -86,7 +86,7 @@ exports.queryParams = (obj) => {
 
 // Map style JSON
 exports.getMapStyle = (p) => {
-	return fetch(CONFIG.VECT_STYLE)
+	return fetch(CONFIG.VECT_STYLE, { headers: { "Origin": CONFIG.WEBSITE_URL } })
 	.then(res => res.ok ? res.json() : getFallbackStyle())
 	.then(style => {
 		const legend = [];
@@ -359,7 +359,7 @@ exports.getMapStyle = (p) => {
 
 // Map style JSON for statistics
 exports.getMapStatsStyle = (p, maxPerLevel) => {
-	return fetch(CONFIG.VECT_STYLE)
+	return fetch(CONFIG.VECT_STYLE, { headers: { "Origin": CONFIG.WEBSITE_URL } })
 	.then(res => res.ok ? res.json() : getFallbackStyle())
 	.then(style => {
 		let colors = {


### PR DESCRIPTION
- Currently if an instance admin forgets to launch the install script and launches the init script it runs for some time loading data on the DB and doing stuff and then explodes because a table is missing, so it's necessary to reset, run install and run init again. With these changes to 10_features_update.js init throws an error immediately.
- Adds pgadmin to docker compose with a config such that it does not start  with a normal startup (`docker compose up`) but only if specifically requesting it to start (`docker compose --profile pgadmin up`)
- fixes some typos in DEVELOP.md
- Updates some parts of the website to make them translatable
<img width="1284" height="921" alt="image" src="https://github.com/user-attachments/assets/55ec15fa-47aa-4452-aac2-4ba16e8bcaad" />
<img width="1153" height="425" alt="image" src="https://github.com/user-attachments/assets/e29e10c8-465a-43db-813b-376ef876430c" />


NOTE: I'm struggling to understand how to test stats.pug line 189 so I haven't tested it yet, please help me understand that or make sure yourself that it's working correctly