### PR TITLE
Add delta monitoring in boundaries stats, improve stats map

### DIFF
--- a/db/01_setup_schema.sql
+++ b/db/01_setup_schema.sql
@@ -58,6 +58,30 @@ CREATE TABLE pdm_counts_dates (
 );
 CREATE INDEX ON pdm_counts_dates using btree(project_id, ts);
 
+CREATE VIEW pdm_counts_dates_deltas AS (
+WITH ordered_delta AS (
+  SELECT
+    project_id,
+    ts,
+    ts - LEAD(ts) OVER (PARTITION BY project_id ORDER BY ts DESC) AS delta_last
+  FROM pdm_counts_dates
+),
+dates_sequeces AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY project_id ORDER BY ts desc) - ROW_NUMBER() OVER (PARTITION BY project_id, delta_last ORDER BY ts desc) AS seq
+  FROM ordered_delta
+)
+SELECT
+  project_id,
+  max(ts) as ts,
+  delta_last as delta,
+  COUNT(ts) AS counter
+  FROM dates_sequeces
+  GROUP BY project_id, delta_last, seq
+  ORDER by ts
+);
+
 CREATE TABLE pdm_feature_counts(
 	project_id int NOT NULL,
 	ts TIMESTAMP NOT NULL,

--- a/db/10_features_update.js
+++ b/db/10_features_update.js
@@ -45,6 +45,8 @@ const yamlData = {
 
 const preSQL = [
 	"DROP MATERIALIZED VIEW IF EXISTS pdm_boundary_tiles CASCADE",
+	"DROP MATERIALIZED VIEW IF EXISTS pdm_boundary_stats CASCADE",
+	"DROP MATERIALIZED VIEW IF EXISTS pdm_boundary_dash CASCADE",
 	"DROP MATERIALIZED VIEW IF EXISTS pdm_boundary_subdivide CASCADE"
 ]; // Suppression des ressources projets
 const postSQL = []; // Creation des ressources projets

--- a/db/12_features_post_init.sql
+++ b/db/12_features_post_init.sql
@@ -6,8 +6,8 @@ FROM pdm_boundary;
 CREATE INDEX ON pdm_boundary_subdivide using gist(geom);
 CREATE INDEX ON pdm_boundary_subdivide using btree(osm_id);
 
--- Boundary stats for tiles
-CREATE MATERIALIZED VIEW pdm_boundary_tiles AS
+-- Boundaries common statistics
+CREATE MATERIALIZED VIEW pdm_boundary_stats AS
 WITH boundaries as (
 	SELECT DISTINCT fb.project_id, fb.boundary, b.name, b.admin_level, b.centre as geom
 	FROM pdm_feature_counts_per_boundary fb
@@ -19,17 +19,40 @@ stats as (
 		d.project_id,
 		NULL as label,
 		COALESCE(fb.amount, 0) as amount,
+		COALESCE(lag(fb.amount) over project_window, 0) as amount_prev,
 		d.ts,
 		b.name,
 		b.admin_level,
 		b.geom,
-		COALESCE(last_value(fb.amount) over project_window, 0) - COALESCE(first_value(fb.amount) over project_window, 0) as nb
+		COALESCE(last_value(fb.amount) over project_window, 0) - COALESCE(first_value(fb.amount) over project_window, 0) as delta_project,
+		COALESCE(fb.amount, 0) - COALESCE(lag(fb.amount) over project_window, 0) as delta_prev
 	FROM pdm_counts_dates d
 	JOIN boundaries b ON b.project_id=d.project_id
 	LEFT JOIN pdm_feature_counts_per_boundary fb ON fb.project_id=d.project_id AND fb.ts=d.ts AND fb.boundary=b.boundary
 	WHERE fb.label IS NULL
 	WINDOW project_window AS (PARTITION BY d.project_id, b.boundary ORDER BY d.ts ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 )
+SELECT
+	s.boundary as boundary,
+	s.project_id,
+	s.label,
+	s.name,
+	s.admin_level,
+	s.geom,
+	json_object(array_agg(s.ts::date::text), array_agg(s.amount::text)) AS amounts_json,
+	json_object(array_agg(s.ts::date::text), array_agg(s.delta_prev::text)) AS deltas_json,
+	array_agg(s.delta_prev) AS deltas,
+	(array_agg(s.delta_prev))[array_upper(array_agg(s.delta_prev), 1)] as delta_daily,
+	s.delta_project
+FROM stats s
+GROUP BY s.project_id, s.label, s.boundary, s.delta_project, s.name, s.admin_level, s.geom;
+
+CREATE INDEX pdm_boundary_stats_project_idx ON pdm_boundary_stats(project_id);
+CREATE INDEX pdm_boundary_stats_admin_idx ON pdm_boundary_stats(admin_level);
+CREATE INDEX pdm_boundary_stats_label_idx ON pdm_boundary_stats(label);
+
+-- Boundaries statistics for tiles
+CREATE MATERIALIZED VIEW pdm_boundary_tiles AS
 SELECT
 	s.boundary as id,
 	s.boundary as boundary,
@@ -38,13 +61,91 @@ SELECT
 	s.name,
 	s.admin_level,
 	s.geom,
-	json_object(array_agg(s.ts::date::text), array_agg(s.amount::text)) AS stats,
-	s.nb
-FROM stats s
-GROUP BY s.project_id, s.label, s.boundary, s.nb, s.name, s.admin_level, s.geom;
+	s.amounts_json as stats,
+	s.delta_project,
+	s.delta_daily
+FROM pdm_boundary_stats s WHERE s.label IS NULL;
 
 CREATE INDEX pdm_boundary_tiles_project_idx ON pdm_boundary_tiles(project_id);
 CREATE INDEX pdm_boundary_tiles_geom_idx ON pdm_boundary_tiles USING GIST(geom);
+
+-- Boundaries statistics for dashboard
+-- Dashboard is built on 20 or fewer last days of contribution. Typical contribution ranges for each admin_level come from 1st and 4th quartiles
+CREATE MATERIALIZED VIEW pdm_boundary_dash AS
+WITH delta_length AS (
+  -- For each project, get the most continuous and recent period of daily deltas in the counts list
+  SELECT
+	project_id,
+	first_value(ts) over ts_window as ts,
+	least(20, first_value(counter) over ts_window) as counter
+  FROM pdm_counts_dates_deltas
+  WHERE delta=interval '1 day'
+  WINDOW ts_window as (PARTITION BY project_id order by ts desc)
+),
+delta_rank AS (
+  -- For each label, admin_level of each project, ranking each delta in ascending order
+  SELECT
+    s.project_id,
+    s.admin_level,
+    s.label,
+    unnest(s.deltas[array_length(s.deltas, 1)-dl.counter:array_length(s.deltas, 1)]) as delta,
+    PERCENT_RANK() OVER last_window as percentile_rank
+  FROM pdm_boundary_stats s
+  JOIN delta_length dl ON dl.project_id=s.project_id
+  WINDOW last_window AS (PARTITION BY s.project_id, s.admin_level, s.label ORDER BY unnest(s.deltas[array_length(s.deltas, 1)-dl.counter:array_length(s.deltas, 1)]) ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+),
+bottom_10 AS (
+  -- For each label, admin_level of each project, fiding the least quartile of delta
+  SELECT project_id, admin_level, label, round(AVG(delta)) as delta
+  FROM delta_rank
+  WHERE percentile_rank <= 0.25
+  GROUP BY project_id, admin_level, label
+),
+top_10 AS (
+  -- For each label, admin_level of each project, fiding the greatest quartile of delta
+  SELECT project_id, admin_level, label, round(avg(delta)) as delta
+  FROM delta_rank
+  WHERE percentile_rank >= 0.75
+  GROUP BY project_id, admin_level, label
+),
+boundaries_activity as (
+  -- For each label, admin_level of each project, fiding the least and most active boundaries
+  SELECT DISTINCT
+    s.project_id,
+    s.admin_level,
+    s.label,
+	first_value(s.delta_project) over full_window as delta_project_min,
+	last_value(s.delta_project) over full_window as delta_project_max,
+    first_value(s.boundary) over full_window as boundary_min,
+    last_value(s.boundary) over full_window as boundary_max
+  FROM pdm_boundary_stats s
+  WINDOW full_window AS (PARTITION BY s.project_id, s.admin_level, s.label ORDER BY s.delta_project ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+),
+admlevel_stats as (
+  -- For each label, admin_level of each project, combining the quartiles to get the daily average contributing range
+  SELECT
+    b.project_id,
+    b.admin_level,
+    b.label,
+    min(b.delta) as delta_daily_min,
+    max(t.delta) as delta_daily_max
+    FROM bottom_10 b
+    JOIN top_10 t ON t.project_id=b.project_id AND t.admin_level=b.admin_level AND coalesce(t.label,'_global')=coalesce(b.label,'_global')
+    GROUP BY b.project_id, b.admin_level, b.label
+)
+-- Finally combining daily average contributing range and least/most active areas to get the boundaries dashboard data
+SELECT 
+    a.project_id,
+    a.admin_level,
+    a.label,
+    b.delta_project_min,
+    b.delta_project_max,
+    a.delta_daily_min,
+    a.delta_daily_max,
+    b.boundary_min,
+    b.boundary_max
+FROM admlevel_stats a
+JOIN boundaries_activity b ON b.project_id=a.project_id AND b.admin_level=a.admin_level AND coalesce(b.label,'_global')=coalesce(a.label,'_global');
 
 -- Filtered tiles function for pg_tileserv
 CREATE OR REPLACE FUNCTION pdm_boundary_project_tiles(z integer, x integer, y integer, prjid int) RETURNS bytea AS $$
@@ -57,7 +158,7 @@ BEGIN
 	mvtgeom AS (
 		SELECT
 			ST_AsMVTGeom(t.geom, bounds.geom) AS geom,
-			t.boundary, t.name, t.admin_level, t.stats, t.nb
+			t.boundary, t.name, t.admin_level, t.stats, t.delta_project, t.delta_daily
 		FROM pdm_boundary_tiles t, bounds
 		WHERE
 			t.project_id = prjid

--- a/db/20_changes_update.js
+++ b/db/20_changes_update.js
@@ -334,7 +334,7 @@ fi
 
 if ${HAS_BOUNDARY}; then
     echo "   => Refresh boundary tiles"
-    ${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_tiles"
+    ${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_stats; REFRESH MATERIALIZED VIEW pdm_boundary_tiles; REFRESH MATERIALIZED VIEW pdm_boundary_dash"
 fi
 
 ${separator}

--- a/db/30_projects_update.js
+++ b/db/30_projects_update.js
@@ -198,13 +198,15 @@ process_start_ts=\${process_qry[0]}
 process_start_day=\$(date -d "\$process_start_ts" +%-d)
 process_start_month=\$(date -d "\$process_start_ts" +%-m)
 process_start_year=\$(date -d "\$process_start_ts" +%Y)
+process_start_time=$(date -d "\$process_start_ts" +%s --utc)
 process_end_ts=\${process_qry[1]}
-process_end_time=\$(date -d "\$process_end_ts" +%s)
+process_end_time=\$(date -d "\$process_end_ts" +%s --utc)
 process_end_day=\$(date -d "\$process_end_ts" +%-d)
 process_end_month=\$(date -d "\$process_end_ts" +%-m)
 process_end_year=\$(date -d "\$process_end_ts" +%Y)
 echo "== Statistics for project ${project.name}" between \$process_start_ts and \$process_end_ts
 process_start_t0=$(date -d now +%s)`;
+
     // Dénombrements
     if (project.statistics.count){
         script += `
@@ -213,13 +215,15 @@ if [[ \$process_start_ts == \$process_end_ts ]]; then
 else
     echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Counting features"
     count_dates_list=""
+    
     process_interm_time=\$(date -d "\${process_end_year}-\${process_end_month}-01T00:00:00Z" +%s --utc)
     if (( \$process_end_day <= 15 )); then
         process_interm_time=$((\$process_interm_time - 20*86400))
+        process_interm_time=$(($process_interm_time < $process_start_time ? $process_start_time : $process_interm_time))
     fi
     process_interm_year=\$(date -d "@\$process_interm_time" +%Y)
     process_interm_month=\$(date -d "@\$process_interm_time" +%-m)
-    if [[ "\$process_start_month" != "\$process_end_month" ]] || [[ "\$process_start_year" != "\$process_end_year" ]]; then
+    if (( (\$process_end_time - \$process_start_time) > (31*86400) )) && [[ "\$process_start_month" != "\$process_end_month" || "\$process_start_year" != "\$process_end_year" ]]; then
         for ((count_date_year=process_start_year; count_date_year<=process_interm_year; count_date_year++))
             do
             count_date_month=\$((count_date_year == process_start_year ? process_start_month : 1))
@@ -235,7 +239,7 @@ else
         process_interm_day=\$process_start_day
     fi
     process_interm_time=\$(date -d "\${process_interm_year}-\${process_interm_month}-\${process_interm_day}T00:00:00Z" +%s --utc)
-    for((count_date_offset=process_interm_time; count_date_offset<process_end_time; count_date_offset+=86400))
+    for ((count_date_offset=process_interm_time; count_date_offset<process_end_time; count_date_offset+=86400))
         do
         count_date_current=\$(date -d "@\$count_date_offset" +'%Y-%m-%dT00:00:00Z')
         count_dates_list="('\$count_date_current', '\$count_date_current'::timestamp - interval '1 day'),\$count_dates_list"
@@ -285,7 +289,8 @@ ${separator}
 script += `
 if ${HAS_BOUNDARY}; then
     echo "== Refresh boundary tiles"
-    ${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_tiles"
+    ${PSQL} -c "REFRESH MATERIALIZED VIEW pdm_boundary_stats; REFRESH MATERIALIZED VIEW pdm_boundary_tiles; REFRESH MATERIALIZED VIEW pdm_boundary_dash"
+    echo " [\$((\$(date -d now +%s) - \$process_start_t0))s] done"
 fi
 ${separator}
 `;

--- a/db/33_projects_contribs.sql
+++ b/db/33_projects_contribs.sql
@@ -26,12 +26,14 @@ UPDATE pdm_projects_teams SET userid=uknownusers.userid FROM uknownusers WHERE u
 
 -- Establishing user contributions in every running project
 WITH features as (
+    -- Retreiving changed features with their label and corresponding contributions
     SELECT d.ts::date, fc.osmid, fc.version, fc.userid, fc.contrib, fl.contrib as label_contrib, coalesce(fl.label,'no-label') as label, fc.geom_len, fc.geom_area, fc.geom_len_delta, fc.geom_area_delta
     FROM :changes_table fc
     JOIN pdm_mapper_counts_dates d ON fc.ts_start BETWEEN d.ts_past AND d.ts
     LEFT JOIN :labels_table fl ON fl.osmid=fc.osmid AND fl.version=fc.version
     WHERE fc.tagsfilter=true
 ), counts as (
+    -- Compute amounts, length and surface delta for each day, user, label and contribution
     SELECT 
       f.ts,
       f.userid,
@@ -48,6 +50,7 @@ WITH features as (
     GROUP BY f.ts, f.userid, f.contrib, f.label_contrib, ROLLUP(f.label)
     HAVING f.label != 'no-label' OR f.label IS NULL
 ), contributions as (
+    -- Conflate global and label contributions, amounts, length and surface deltas
     SELECT c.userid,
       c.ts,
       c.label,
@@ -71,6 +74,7 @@ WITH features as (
       end as geom_area_delta
     FROM counts c
 )
+-- Finally insert qualified contribution in the table
 INSERT INTO pdm_user_contribs(project_id, userid, ts, label, contribution, amount_delta, len_delta, area_delta, points)
     SELECT :project_id as project_id,
       cc.userid,
@@ -87,7 +91,8 @@ INSERT INTO pdm_user_contribs(project_id, userid, ts, label, contribution, amoun
       SUM(cc.geom_area_delta) AS area_delta,
       SUM(cc.nb * coalesce(pp.points,0)) AS points
     FROM contributions cc
-    LEFT JOIN pdm_projects_points pp ON cc.contrib=pp.contrib AND coalesce(cc.label,'global')=coalesce(pp.label,'global') AND pp.project_id=:project_id
+    LEFT JOIN pdm_projects_points pp ON cc.contrib=pp.contrib AND coalesce(cc.label,'_global')=coalesce(pp.label,'_global') AND pp.project_id=:project_id
+    WHERE cc.contrib IS NOT NULL
     GROUP BY project_id, cc.ts, cc.userid, cc.label, cc.contrib;
 
 -- Main labels count

--- a/website/index.js
+++ b/website/index.js
@@ -596,18 +596,20 @@ app.get("/projects/:name/stats", (req, res) => {
       allPromises.push(
         pool
           .query(
-            `SELECT admin_level, max(nb) AS amount FROM pdm_boundary_tiles WHERE project_id = $1 AND label IS NULL GROUP BY admin_level`,[
+            `SELECT d.admin_level, d.delta_project_min, d.delta_project_max, d.delta_daily_min, d.delta_daily_max, b.name as boundary_max FROM pdm_boundary_dash d JOIN pdm_boundary b ON b.osm_id=d.boundary_max WHERE project_id = $1 AND label IS NULL`,[
              p.id
           ])
           .then((results) => {
-            const maxLevel = {};
+            const prjDeltaLevel = {};
+            const dailyDeltaLevel = {};
             results.rows.forEach((r) => {
-              if (!isNaN(parseInt(r.amount))) {
-                maxLevel[r.admin_level] = r.amount;
+              if (!isNaN(parseInt(r.delta_project_max))) {
+                prjDeltaLevel[r.admin_level] = {"min":r.delta_project_min, "max":r.delta_project_max, "boundary": r.boundary_max};
               }
+              dailyDeltaLevel[r.admin_level] = [r.delta_daily_min, r.delta_daily_max];
             });
-            return Object.keys(maxLevel).length > 0
-              ? getMapStatsStyle(p, maxLevel)
+            return Object.keys(prjDeltaLevel).length > 0
+              ? getMapStatsStyle(p, prjDeltaLevel, dailyDeltaLevel)
               : null;
           })
           .then((mapStyle) => ({ mapStyle })),

--- a/website/locales/en.json
+++ b/website/locales/en.json
@@ -33,6 +33,7 @@
 	"Last update: ": "Last update: ",
 	"contributors": "contributors",
 	"Total amount": "Total amount",
+	"Total": "Total",
 	"Country": "Country",
 	"Region": "Region",
 	"Department": "Department",

--- a/website/locales/fr.json
+++ b/website/locales/fr.json
@@ -33,6 +33,7 @@
 	"Last update: ": "Dernière mise à jour : ",
 	"contributors": "personnes contributrices",
 	"Total amount": "Nombre total",
+	"Total": "Total",
 	"Country": "Pays",
 	"Region": "Région",
 	"Department": "Département",

--- a/website/locales/it.json
+++ b/website/locales/it.json
@@ -33,6 +33,7 @@
 	"Last update: ": "Ultimo aggiornamento: ",
 	"contributors": "contributori",
 	"Total amount": "Quantità totale",
+	"Total": "Totale",
 	"Country": "Nazione",
 	"Region": "Regione",
 	"Department": "Provincia",

--- a/website/templates/components/stats.pug
+++ b/website/templates/components/stats.pug
@@ -384,7 +384,13 @@ script.
 							}
 						});
 
-						div.appendChild(document.createTextNode(f.properties.name));
+						const titleSpan = document.createElement("span");
+						titleSpan.classList.add("font-weight-bold");
+						titleSpan.appendChild(document.createTextNode(f.properties.name));
+
+						div.appendChild(titleSpan);
+						div.appendChild(createDeltaElement(f.properties.delta_project, ` #{__("Total")} `, false));
+						div.appendChild(createDeltaElement(f.properties.delta_daily, ` 24h `, false));
 						div.appendChild(canvas);
 
 						popupHover.remove();
@@ -405,7 +411,15 @@ script.
 						}
 
 						const div = document.createElement("div");
-						div.appendChild(document.createTextNode(`${f.properties.name} : ${f.properties.nb}`));
+						const spanTitle = document.createElement("span");
+						spanTitle.appendChild(document.createTextNode(`${f.properties.name}`));
+						spanTitle.classList.add("font-weight-bold")
+						const spanFull = document.createElement("span");
+						spanFull.appendChild(document.createTextNode(`${f.properties.delta_project}`));
+						div.appendChild(spanTitle);
+						div.appendChild(document.createElement("br"));
+						div.appendChild(spanFull);
+						div.appendChild(createDeltaElement(f.properties.delta_daily, null, true));
 						popupHover.setLngLat(coords).setDOMContent(div).addTo(mapStats);
 					}
 				});
@@ -421,9 +435,10 @@ script.
 				const admLvlToText = { "2": "#{__("Country")}", "4": "#{__("Region")}", "6": "#{__("Department")}", "8": "#{__("City")}" };
 				Object.entries(res.mapStyle.legend).forEach(e => {
 					const [lvl, data] = e;
+					let symbol2BackgroundGradient;
 
-					const div = document.createElement("div");
-					div.classList.add("col-md-4", "d-flex", "justify-content-start", "align-items-center");
+					const itemDiv = document.createElement("div");
+					itemDiv.classList.add("col-md-4", "d-flex", "justify-content-start", "align-items-center");
 					const symbol1 = document.createElement("div");
 					symbol1.classList.add("map-stats-symbol");
 					symbol1.style.width = `${Math.ceil(data.minSize*1.5)}px`;
@@ -431,22 +446,113 @@ script.
 					symbol1.style.borderRadius = `${Math.ceil(data.minSize*1.5/2)}px`;
 					symbol1.style.backgroundColor = data.color;
 
+					const symbol1LabelDiv = document.createElement("div");
+					symbol1LabelDiv.classList.add("text-right");
+					const symbol1LabelBoundary = document.createElement("div");
+					symbol1LabelBoundary.classList.add("map-stats-symbol-boundary");
+					const symbol1LabelBoundaryLabel = document.createElement("span");
+					symbol1LabelBoundaryLabel.classList.add("font-weight-bold");
+					symbol1LabelBoundaryLabel.appendChild(document.createTextNode(`${admLvlToText[lvl]}`));
+					symbol1LabelBoundary.appendChild(symbol1LabelBoundaryLabel);
+					symbol1LabelBoundary.appendChild(document.createElement("br"));
+					symbol1LabelBoundary.appendChild(document.createTextNode(`${data.prjDeltaMin}`));
+					symbol1LabelDiv.appendChild(symbol1LabelBoundary);
+
+					const symbol1LabelLowerDelta = document.createElement ("div");
+					symbol1LabelLowerDelta.classList.add("map-stats-symbol-dailydelta");
+					symbol1LabelLowerDelta.appendChild(document.createTextNode("Global "));
+					const symbol1LabelLowerDeltaLabel = document.createElement("span");
+					symbol1LabelLowerDeltaLabel.style.textDecoration = "overline";
+					symbol1LabelLowerDeltaLabel.appendChild(document.createTextNode("24h"));
+					symbol1LabelLowerDelta.appendChild(symbol1LabelLowerDeltaLabel);
+					symbol1LabelLowerDelta.appendChild(document.createTextNode(" "));
+					if (data.dailyDeltaMin != 0){
+						symbol1LabelLowerDelta.appendChild(createDeltaElement(data.dailyDeltaMin, null, false));
+						symbol2BackgroundGradient = "#DF0000"
+					}else{
+						symbol1LabelLowerDelta.appendChild(document.createTextNode("-"));
+						symbol2BackgroundGradient = "grey"
+					}
+					symbol1LabelDiv.appendChild(symbol1LabelLowerDelta);
+
+					symbol2BackgroundGradient += ", white";
+
 					const symbol2 = symbol1.cloneNode(true);
+					symbol2.classList.add("map-stats-symbol-casing");
 					symbol2.style.width = `${Math.ceil(data.maxSize*1.5)}px`;
 					symbol2.style.height = `${Math.ceil(data.maxSize*1.5)}px`;
 					symbol2.style.borderRadius = `${Math.ceil(data.maxSize*1.5/2)}px`;
 
-					div.appendChild(document.createTextNode(`${admLvlToText[lvl]} : ${data.minValue}`));
-					div.appendChild(symbol1);
-					div.appendChild(symbol2);
-					div.appendChild(document.createTextNode(data.maxValue));
-					mapStatsLegend.appendChild(div);
+					const symbol2LabelDiv = document.createElement("div");
+					const symbol2LabelBoundary = document.createElement("div");
+					symbol2LabelBoundary.classList.add("map-stats-symbol-boundary");
+					const symbol2LabelBoundaryLabel = document.createElement("span");
+					symbol2LabelBoundaryLabel.appendChild(document.createTextNode(`${data.maxBoundary}`));
+					symbol2LabelBoundary.appendChild(symbol2LabelBoundaryLabel);
+					symbol2LabelBoundary.appendChild(document.createElement("br"));
+					symbol2LabelBoundary.appendChild(document.createTextNode(`${data.prjDeltaMax}`));
+					symbol2LabelDiv.appendChild(symbol2LabelBoundary);
+
+					const symbol2LabelUpperDelta = document.createElement ("div");
+					symbol2LabelUpperDelta.classList.add("map-stats-symbol-dailydelta");
+					symbol2LabelUpperDelta.appendChild(document.createTextNode("Global "));
+					const symbol2LabelUpperDeltaLabel = document.createElement("span");
+					symbol2LabelUpperDeltaLabel.style.textDecoration = "overline";
+					symbol2LabelUpperDeltaLabel.appendChild(document.createTextNode("24h"));
+					symbol2LabelUpperDelta.appendChild(symbol2LabelUpperDeltaLabel);
+					symbol2LabelUpperDelta.appendChild(document.createTextNode(" "));
+					if (data.dailyDeltaMax != 0){
+						symbol2LabelUpperDelta.appendChild(createDeltaElement(data.dailyDeltaMax, null, false));
+						symbol2BackgroundGradient += ", #24b424"
+					}else{
+						symbol2LabelUpperDelta.appendChild(document.createTextNode("-"));
+						symbol2BackgroundGradient += ", grey"
+					}
+					symbol2LabelDiv.appendChild(symbol2LabelUpperDelta);
+
+					symbol2.style.background = `linear-gradient(${data.color}, ${data.color}) padding-box, linear-gradient(to right, ${symbol2BackgroundGradient}) border-box`;
+
+					itemDiv.appendChild(symbol1LabelDiv);
+					itemDiv.appendChild(symbol1);
+					itemDiv.appendChild(symbol2);
+					itemDiv.appendChild(symbol2LabelDiv);
+					mapStatsLegend.appendChild(itemDiv);
 				});
 			}
 			else {
 				mapStatsContainer.parentNode.classList.add("d-none");
 			}
 		});
+	}
+
+	const createDeltaElement = (delta, title, detail) => {
+		let delta_label = "0";
+		let delta_colour = "#000000";
+		if (delta < 0){
+			delta_label = `\u25bc ${delta}`
+			delta_colour = "#8b0a0a"
+		}else if (delta > 0){
+			delta_label = `\u25b2 ${delta}`
+			delta_colour = "#17791d"
+		}
+
+		if (detail){
+			delta_label = `\u00a0(${delta_label})`;
+		}
+
+		let spanDelta = document.createElement("span");
+		spanDelta.appendChild(document.createTextNode(`${delta_label}`));
+		spanDelta.style.color = delta_colour;
+		let spanResult = spanDelta;
+
+		if (title != null){
+			let spanTitle = document.createElement("span");
+			spanTitle.appendChild(document.createTextNode(title));
+			spanTitle.appendChild(spanDelta);
+			spanResult = spanTitle;
+		}
+
+		return spanResult;
 	}
 
 	let delayDisplayStats;

--- a/website/templates/style.css
+++ b/website/templates/style.css
@@ -1004,6 +1004,19 @@ input:checked + .slider:before {
 	text-align: center;
 	color: white;
 }
+#map-stats-legend .map-stats-symbol-casing {
+	border: 4px solid transparent;
+}
+#map-stats-legend .map-stats-symbol-dailydelta {
+	padding: 0 3px;
+	font-size: 80%;
+	background-color: #D9D9D9;
+	border-radius: 3px;
+}
+#map-stats-legend .map-stats-symbol-boundary {
+	padding: 0 3px;
+	margin-bottom: 3px;
+}
 
 .map-stats-popup {
 	width: 400px;

--- a/website/utils.js
+++ b/website/utils.js
@@ -358,13 +358,13 @@ exports.getMapStyle = (p) => {
 };
 
 // Map style JSON for statistics
-exports.getMapStatsStyle = (p, maxPerLevel) => {
+exports.getMapStatsStyle = (p, prjDeltaPerLevel, dailyDeltaPerLevel) => {
 	return fetch(CONFIG.VECT_STYLE, { headers: { "Origin": CONFIG.WEBSITE_URL } })
 	.then(res => res.ok ? res.json() : getFallbackStyle())
 	.then(style => {
 		let colors = {
-			"2": "#fe3521",
-			"4": "#2196F3",
+			"2": "#a32b20",
+			"4": "#186fb6",
 			"6": "#4A148C",
 			"8": "#004D40"
 		}
@@ -387,18 +387,31 @@ exports.getMapStatsStyle = (p, maxPerLevel) => {
 		if(p && p.statistics && p.statistics.count) {
 			let circleColors = ["match", ["get", "admin_level"]];
 			let circlesRadius = ["match", ["get", "admin_level"]];
+			let circlesStrokeColor = ["match", ["get", "admin_level"]];
+			let circlesStrokeWidth = ["match", ["get", "admin_level"]];
 			let condOpacity = ["interpolate", ["linear"], ["zoom"]];
 			let oldZLevel = null;
 
 			Object.keys(adminLevels).forEach(adminLevel => {
-				if (maxPerLevel.hasOwnProperty(adminLevel)){
-					let minVal = Math.min(1, maxPerLevel[adminLevel]);
-					legend[adminLevel] = { color: colors[adminLevel], minSize: 3, minValue: minVal, maxSize: maxSizes[adminLevel], maxValue: maxPerLevel[adminLevel] };
-					
-					if (minVal < maxPerLevel[adminLevel]){
-						circlesRadius.push(parseInt(adminLevel));
-						circlesRadius.push(["interpolate", ["linear"], ["get", "nb"], 0, 0, minVal, 3, maxPerLevel[adminLevel], maxSizes[adminLevel]]);
-						circleColors.push(parseInt(adminLevel));
+				let admLvl = parseInt(adminLevel);
+
+				if (prjDeltaPerLevel.hasOwnProperty(adminLevel)){
+					let minDelta = Math.min(1, prjDeltaPerLevel[adminLevel].max);
+					legend[adminLevel] = {
+						color: colors[adminLevel],
+						minSize: 3,
+						prjDeltaMin: prjDeltaPerLevel[adminLevel].min,
+						prjDeltaMax: prjDeltaPerLevel[adminLevel].max,
+						dailyDeltaMin: 0,
+						dailyDeltaMax: 0,
+						maxSize: maxSizes[adminLevel],
+						maxBoundary: prjDeltaPerLevel[adminLevel].boundary
+					};
+
+					if (minDelta < prjDeltaPerLevel[adminLevel].max){
+						circlesRadius.push(admLvl);
+						circlesRadius.push(["interpolate", ["linear"], ["get", "delta_project"], 0, 0, minDelta, 3, parseInt(prjDeltaPerLevel[adminLevel].max), maxSizes[adminLevel]]);
+						circleColors.push(admLvl);
 						circleColors.push(colors[adminLevel]);
 
 						if (oldZLevel != null){
@@ -406,14 +419,40 @@ exports.getMapStatsStyle = (p, maxPerLevel) => {
 							condOpacity.push(0);
 						}
 						for (zLevel of adminLevels[adminLevel]){
-							condOpacity.push(zLevel, ["case", ["==", ["get", "admin_level"], parseInt(adminLevel)], 1, 0 ]);
+							condOpacity.push(zLevel, ["case", ["==", ["get", "admin_level"], admLvl], 1, 0 ]);
 							oldZLevel = zLevel;
 						}
+					}
+				}
+				if (dailyDeltaPerLevel.hasOwnProperty(adminLevel)){
+					let dailyDeltaMin = parseInt(dailyDeltaPerLevel[adminLevel][0]);
+					let dailyDeltaMax = parseInt(dailyDeltaPerLevel[adminLevel][1]);
+
+					legend[adminLevel].dailyDeltaMin = dailyDeltaMin;
+					legend[adminLevel].dailyDeltaMax = dailyDeltaMax;
+
+					if (dailyDeltaMin < 0 || dailyDeltaMax > 0){
+						let strWidthInterpolate = ["interpolate", ["linear"], ["get", "delta_daily"]];
+						let strColorInterpolate = ["interpolate", ["linear"], ["get", "delta_daily"]];
+
+						strWidthInterpolate.push(Math.min(-3, dailyDeltaMin), 4);
+						strColorInterpolate.push(Math.min(-3, dailyDeltaMin), "#DF0000");
+						strWidthInterpolate.push(0, 2);
+						strColorInterpolate.push(0, "#FFFFFF");
+						strWidthInterpolate.push(Math.max(3, dailyDeltaMax), 4);
+						strColorInterpolate.push(Math.max(3, dailyDeltaMax), "#24b424");
+
+						circlesStrokeWidth.push(admLvl);
+						circlesStrokeWidth.push(strWidthInterpolate);
+						circlesStrokeColor.push(admLvl);
+						circlesStrokeColor.push(strColorInterpolate);
 					}
 				}
 			});
 			circlesRadius.push(0);
 			circleColors.push ("#999999");
+			circlesStrokeWidth.push(2);
+			circlesStrokeColor.push ("#FFFFFF");
 
 			// Source stats
 			p.datasources
@@ -439,8 +478,8 @@ exports.getMapStatsStyle = (p, maxPerLevel) => {
 						"circle-sort-key": ["-", ["get", "nb"]]
 					},
 					paint: {
-						"circle-stroke-color": "white",
-						"circle-stroke-width": 2,
+						"circle-stroke-color": circlesStrokeColor,
+						"circle-stroke-width": circlesStrokeWidth,
 						"circle-stroke-opacity": condOpacity,
 						"circle-color": circleColors,
 						"circle-opacity": condOpacity,


### PR DESCRIPTION
I propose several improvements regarding daily activity monitoring in projects:
* Add a visual representation of daily changes on every boundary on stats map. Contributes to #358 without completely fixing it.
* Mention delta on pop ups, both hover and click
* Add label for corresponding boundaries in map legend, fix #410 
* Several corresponding changes in database

Ranges to compute red to green strokes around boundaries circles on the map are dynamically set. Podoma computes the average daily delta in the first and last quartile of every admin_level of each project.  
Ranges are then integrated to the stats map style and the tiles are provided with additional `delta_last` (delta between now and 24h ago for a given boundary) and `delta_full` (delta between now and the beginning of the project for a given boundary) fields.

<img width="1146" height="625" alt="image" src="https://github.com/user-attachments/assets/f9cf80f9-d9bc-443a-99d0-ab6d0973809a" />

This PR also fixes a bug related to `pdm_counts_dates` table. The date incrementation was too broad and repeated dates from M-1 instead D-1 at daily update.

Minor adjustments may be required to the map rendering, depending on your comments.
See it live here: https://enedis.openstreetmap.fr/projects/2021-01_poteaux

Following steps are necessary to upgrade after merging this PR:

```sql
CREATE MATERIALIZED VIEW pdm_boundary_stats AS
WITH boundaries as (
	SELECT DISTINCT fb.project_id, fb.boundary, b.name, b.admin_level, b.centre as geom
	FROM pdm_feature_counts_per_boundary fb
	JOIN pdm_boundary b ON b.osm_id=fb.boundary
),
stats as (
	SELECT 
		b.boundary,
		d.project_id,
		NULL as label,
		COALESCE(fb.amount, 0) as amount,
		COALESCE(lag(fb.amount) over project_window, 0) as amount_prev,
		d.ts,
		b.name,
		b.admin_level,
		b.geom,
		COALESCE(last_value(fb.amount) over project_window, 0) - COALESCE(first_value(fb.amount) over project_window, 0) as delta_project,
		COALESCE(fb.amount, 0) - COALESCE(lag(fb.amount) over project_window, 0) as delta_prev
	FROM pdm_counts_dates d
	JOIN boundaries b ON b.project_id=d.project_id
	LEFT JOIN pdm_feature_counts_per_boundary fb ON fb.project_id=d.project_id AND fb.ts=d.ts AND fb.boundary=b.boundary
	WHERE fb.label IS NULL
	WINDOW project_window AS (PARTITION BY d.project_id, b.boundary ORDER BY d.ts ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
)
SELECT
	s.boundary as boundary,
	s.project_id,
	s.label,
	s.name,
	s.admin_level,
	s.geom,
	json_object(array_agg(s.ts::date::text), array_agg(s.amount::text)) AS amounts_json,
	json_object(array_agg(s.ts::date::text), array_agg(s.delta_prev::text)) AS deltas_json,
	array_agg(s.delta_prev) AS deltas,
	(array_agg(s.delta_prev))[array_upper(array_agg(s.delta_prev), 1)] as delta_daily,
	s.delta_project
FROM stats s
GROUP BY s.project_id, s.label, s.boundary, s.delta_project, s.name, s.admin_level, s.geom;

CREATE INDEX pdm_boundary_stats_project_idx ON pdm_boundary_stats(project_id);
CREATE INDEX pdm_boundary_stats_admin_idx ON pdm_boundary_stats(admin_level);
CREATE INDEX pdm_boundary_stats_label_idx ON pdm_boundary_stats(label);

DROP MATERIALIZED VIEW pdm_boundary_tiles;
CREATE MATERIALIZED VIEW pdm_boundary_tiles AS
SELECT
	s.boundary as id,
	s.boundary as boundary,
	s.project_id,
	s.label,
	s.name,
	s.admin_level,
	s.geom,
	s.amounts_json as stats,
	s.delta_project,
	s.delta_daily
FROM pdm_boundary_stats s WHERE s.label IS NULL;

CREATE INDEX pdm_boundary_tiles_project_idx ON pdm_boundary_tiles(project_id);
CREATE INDEX pdm_boundary_tiles_geom_idx ON pdm_boundary_tiles USING GIST(geom);

CREATE VIEW pdm_counts_dates_deltas AS (
WITH ordered_delta AS (
  SELECT
    project_id,
    ts,
    ts - LEAD(ts) OVER (PARTITION BY project_id ORDER BY ts DESC) AS delta_last
  FROM pdm_counts_dates
),
dates_sequeces AS (
  SELECT
    *,
    ROW_NUMBER() OVER (PARTITION BY project_id ORDER BY ts desc) - ROW_NUMBER() OVER (PARTITION BY project_id, delta_last ORDER BY ts desc) AS seq
  FROM ordered_delta
)
SELECT
  project_id,
  max(ts) as ts,
  delta_last as delta,
  COUNT(ts) AS counter
  FROM dates_sequeces
  GROUP BY project_id, delta_last, seq
  ORDER by ts
);

-- Boundaries statistics for dashboard
CREATE MATERIALIZED VIEW pdm_boundary_dash AS
WITH delta_length AS (
  SELECT
	project_id,
	first_value(ts) over ts_window as ts,
	least(20, first_value(counter) over ts_window) as counter
  FROM pdm_counts_dates_deltas
  WHERE delta=interval '1 day'
  WINDOW ts_window as (PARTITION BY project_id order by ts desc)
),
delta_rank AS (
  SELECT
    s.project_id,
    s.admin_level,
    s.label,
    unnest(s.deltas[array_length(s.deltas, 1)-dl.counter:array_length(s.deltas, 1)]) as delta,
    PERCENT_RANK() OVER last_window as percentile_rank
  FROM pdm_boundary_stats s
  JOIN delta_length dl ON dl.project_id=s.project_id
  WINDOW last_window AS (PARTITION BY s.project_id, s.admin_level, s.label ORDER BY unnest(s.deltas[array_length(s.deltas, 1)-dl.counter:array_length(s.deltas, 1)]) ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
),
bottom_10 AS (
  SELECT project_id, admin_level, label, round(AVG(delta)) as delta
  FROM delta_rank
  WHERE percentile_rank <= 0.25
  GROUP BY project_id, admin_level, label
),
top_10 AS (
  SELECT project_id, admin_level, label, round(avg(delta)) as delta
  FROM delta_rank
  WHERE percentile_rank >= 0.75
  GROUP BY project_id, admin_level, label
),
boundaries_activity as (
  SELECT DISTINCT
    s.project_id,
    s.admin_level,
    s.label,
	first_value(s.delta_project) over full_window as delta_project_min,
	last_value(s.delta_project) over full_window as delta_project_max,
    first_value(s.boundary) over full_window as boundary_min,
    last_value(s.boundary) over full_window as boundary_max
  FROM pdm_boundary_stats s
  WINDOW full_window AS (PARTITION BY s.project_id, s.admin_level, s.label ORDER BY s.delta_project ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
),
admlevel_stats as (
  SELECT
    b.project_id,
    b.admin_level,
    b.label,
    min(b.delta) as delta_daily_min,
    max(t.delta) as delta_daily_max
    FROM bottom_10 b
    JOIN top_10 t ON t.project_id=b.project_id AND t.admin_level=b.admin_level AND coalesce(t.label,'_global')=coalesce(b.label,'_global')
    GROUP BY b.project_id, b.admin_level, b.label
)
SELECT 
    a.project_id,
    a.admin_level,
    a.label,
    b.delta_project_min,
    b.delta_project_max,
    a.delta_daily_min,
    a.delta_daily_max,
    b.boundary_min,
    b.boundary_max
FROM admlevel_stats a
JOIN boundaries_activity b ON b.project_id=a.project_id AND b.admin_level=a.admin_level AND coalesce(b.label,'_global')=coalesce(a.label,'_global');

CREATE OR REPLACE FUNCTION pdm_boundary_project_tiles(z integer, x integer, y integer, prjid int) RETURNS bytea AS $$
DECLARE
	result bytea;
BEGIN
	WITH bounds AS (
		SELECT ST_TileEnvelope(z, x, y) AS geom
	),
	mvtgeom AS (
		SELECT
			ST_AsMVTGeom(t.geom, bounds.geom) AS geom,
			t.boundary, t.name, t.admin_level, t.stats, t.delta_project, t.delta_daily
		FROM pdm_boundary_tiles t, bounds
		WHERE
			t.project_id = prjid
			AND t.label IS NULL
			AND CASE
				WHEN z < 5 THEN t.admin_level <= 4
				WHEN z >= 5 AND z < 8 THEN t.admin_level = 6
				WHEN z >= 8 THEN t.admin_level = 8
			END
			AND ST_Intersects(t.geom, bounds.geom)
	)
	SELECT ST_AsMVT(mvtgeom, 'public.pdm_boundary_project_tiles') INTO result
	FROM mvtgeom;

	RETURN result;
END;
$$
LANGUAGE 'plpgsql' STABLE PARALLEL SAFE;

-- Remove unecessary dates in pdm_counts_dates
create table pdm_counts_dates_new (like pdm_counts_dates);
insert into pdm_counts_dates_new select distinct project_id, ts, ts_past from pdm_counts_dates;
alter table pdm_counts_dates rename to pdm_counts_dates_bak;
alter table pdm_counts_dates_new rename to pdm_counts_dates;