### PR TITLE
Solving missing delete and missing non-geographic edited features

### DIFF
--- a/db/20_changes_update.js
+++ b/db/20_changes_update.js
@@ -528,17 +528,17 @@ if (( \$process_delta < 1 )); then
 else
     echo "Start processing from: \$process_start_ts to \$process_end_ts"
 
-    changes_src="${OSC_UPDATES_FS}"
+    worlddiff_osc="${OSC_UPDATES_FS}"
     changes_start=\$(date -d "$process_start_ts" +"%Y%m%d")
     changes_end=\$(date -d "$process_end_ts" +"%Y%m%d")
-    changes_osc="\${changes_src/.osc.gz/".time-\$changes_start-\$changes_end.osc.gz"}"
-    changes_oscts="\${changes_src/.osc.gz/".time-\$changes_start-\$changes_end.osc.ts"}"
+    changes_osc="\${worlddiff_osc/.osc.gz/".time-\$changes_start-\$changes_end.osc.gz"}"
+    changes_oscts="\${worlddiff_osc/.osc.gz/".time-\$changes_start-\$changes_end.osc.ts"}"
     if [[ ! -f \$changes_osc ]]; then
         echo "== Build OSC changes with replication files"
-        osmupdate --keep-tempfiles --day -t="${CONFIG.WORK_DIR}/osmupdate/" -v \$process_start_ts "\$changes_src"
+        osmupdate --keep-tempfiles --day -t="${CONFIG.WORK_DIR}/osmupdate/" -v \$process_start_ts "\$worlddiff_osc"
 
         echo "== Read OSC file information..."
-        osc_ts=\$(osmium fileinfo -e -g data.timestamp.last "\$changes_src")
+        osc_ts=\$(osmium fileinfo -e -g data.timestamp.last "\$worlddiff_osc")
         echo \$osc_ts > "\$changes_oscts"
         osc_time=\$(date -d "\$osc_ts" +%s)
         echo "OSC file is up to \$osc_ts"
@@ -548,17 +548,16 @@ else
             script += `
         if [ -f ${POLY_FS} ]; then
             echo "== Extract data in polygon..."
-            osmium extract -p "${POLY_FS}" --with-history -s complete_ways "\$changes_src" -O -o "\$changes_osc"
-            rm -f \$changes_src
+            osmium extract -p "${POLY_FS}" --with-history -s complete_ways "\$worlddiff_osc" -O -o "\$changes_osc"
         else
             echo "== No polygon data to restrict on"
-            mv \$changes_src \$changes_osc
+            cp \$worlddiff_osc \$changes_osc
         fi
         `;
     }else{
             script += `
         echo "== No polygon data to restrict on"
-        mv \$changes_src \$changes_osc
+        cp \$worlddiff_osc \$changes_osc
         `;
     }
 
@@ -659,7 +658,7 @@ Object.values(projects).forEach(project => {
             rm -f "${oplProject}"
             if [[ \$knownfeatures > 0 ]] || [[ \$createdFeatures > 0 ]]; then
                 rm -f "${oscProjectIds}"
-                osmium getid ${getIdOptions} -i "${listKnownIds}" -i "${listCreatedIds}" "\$projectChanges_osc" -o "${oscProjectIds}"
+                osmium getid ${getIdOptions} -i "${listKnownIds}" -i "${listCreatedIds}" "\$worlddiff_osc" -o "${oscProjectIds}"
 
                 echo "   => [\$((\$(date -d now +%s) - \$process_start_t0))s] Merging changes in one file"
                 osmium merge ${oscProjectTags} ${oscProjectIds} -f opl,history=true -o "${oplProject}"


### PR DESCRIPTION
This PR completes the fix for #425 regarding missing delete actions.

Particularly for polygon-filtered projects, non-geographic edits (tags changes on ways or relations without touching nodes for instance) or delete were skipped due to lack of coordinated to compare to polygons.

Then, it's necessary to always seek for existing features waiting to be edited or deleted in the world daily diff instead the filtered one.

Here is the comparison between the existing process and the new one on a ~2M features national project in France.
79 seconds for the old process
106 seconds for the new one.

```
== Begin process for project 2021-01_poteaux
Updating project changes from 2026-04-20T23:59:59Z to 2026-04-21T23:59:52Z
-------------------------------------------------------------------

   => [0s] Extract features from OSH (n/operator=Enedis)
   => [2s] Extract features from OSH (n/power=pole,tower)
   => [10s] Extract 1245151 known features and 1271 created features by their ids
   => [18s] Merging changes in one file
   => [19s] Transform changes into CSV file
   => [19s] Accumulate changes table in database
TRUNCATE TABLE
DELETE 2987
  [19s] Copy features
COPY 3655
  [21s] Fetching missing features from live
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1729    0     0  100  1729      0    204  0:00:08  0:00:08 --:--:--     0
curl: (22) The requested URL returned error: 504
Warning: Problem : HTTP error. Will retry in 1 second. 10 retries left.
100 42456    0 40727  100  1729  35823   1520  0:00:01  0:00:01 --:--:-- 37373
  [35s] 146 features has been retrieved from overpass
COPY 146
  [36s] Populate features
Timing is on.
CREATE INDEX
Time: 23.761 ms
INSERT 0 3133
Time: 292.836 ms
ANALYZE
Time: 3579.397 ms (00:03.579)
  [40s] Refresh changes
REFRESH MATERIALIZED VIEW
  [71s] Process usernames
NOTICE:  table "pdm_features_poteaux_users" does not exist, skipping
DROP TABLE
CREATE TABLE
COPY 3801
INSERT 0 0
DROP TABLE
  [72s] Populate boundaries
Timing is on.
INSERT 0 438
Time: 1262.816 ms (00:01.263)
ANALYZE
Time: 4927.735 ms (00:04.928)
-------------------------------------------------------------------

UPDATE 1
   => [79s] Project update successful
-------------------------------------------------------------------
```
versus
```
== Begin process for project 2021-01_poteaux
Updating project changes from 2026-04-20T23:59:59Z to 2026-04-21T23:59:52Z
-------------------------------------------------------------------

   => [0s] Extract features from OSH (n/operator=Enedis)
   => [1s] Extract features from OSH (n/power=pole,tower)
   => [11s] Extract 1245297 known features and 1271 created features by their ids
   => [53s] Merging changes in one file
   => [53s] Transform changes into CSV file
   => [53s] Accumulate changes table in database
TRUNCATE TABLE
DELETE 2987
  [54s] Copy features
COPY 7781
  [56s] Fetching missing features from live
No missing features found
  [60s] Populate features
Timing is on.
CREATE INDEX
Time: 27.842 ms
INSERT 0 6445
Time: 477.256 ms
ANALYZE
Time: 3778.575 ms (00:03.779)
  [64s] Refresh changes
REFRESH MATERIALIZED VIEW
  [99s] Process usernames
NOTICE:  table "pdm_features_poteaux_users" does not exist, skipping
DROP TABLE
CREATE TABLE
COPY 7927
INSERT 0 0
DROP TABLE
  [100s] Populate boundaries
Timing is on.
INSERT 0 0
Time: 2992.305 ms (00:02.992)
ANALYZE
Time: 3289.796 ms (00:03.290)
-------------------------------------------------------------------

UPDATE 1
   => [106s] Project update successful
-------------------------------------------------------------------
```

It looks like an acceptable change.
It only covers national projects. Worldwide projects already were seeking for existing features in world diff, obviously.

It's recommended to reinit all national projects to catchup on missed delete in the past.