### PR TITLE
Clarifying different coordinates systems in Podoma

### DIFF
--- a/db/10_features_update.js
+++ b/db/10_features_update.js
@@ -179,6 +179,7 @@ if [ "$mode" == "init" ]; then
 	mkdir -p "${IMPOSM_CACHE_DIR}"
 	imposm import -mapping "${IMPOSM_YML_FS}" \\
 		-read "${OSM_PBF_FS}" \\
+		-srid EPSG:3857 \\
 		-overwritecache -cachedir "${IMPOSM_CACHE_DIR}" \\
 		-diff -diffdir "${IMPOSM_DIFF_DIR}"
 

--- a/docs/DEVELOP.fr.md
+++ b/docs/DEVELOP.fr.md
@@ -684,9 +684,11 @@ npm run projects:update
 Il est possible de ne pas utiliser imposm3 et de se connecter à une base de données pourvue des données nécessaires.
 Il faudra s'assurer qu'elle est tenue à jour toutes les heures minimum pour les besoins de PdM.
 
-Optionellement, si le mode compare est activé dans un projet donné, une vue supplémentaire appelée `pdm_project_${project_id}_compare` conforme à ce qui doit être comparé est nécessaire. Elle a la même structure que ci-dessus.
+Une fois configuré, n'oubliez pas de définir `database.live` à `true` dans la configuration de votre projet.
 
 #### Généralités
+
+Toutes les géométries importées par imposm sont prévues pour être affichées sur des tuiles web, la projection EPSG:3857 est alors préférée. Ces géométries diffèrent de celles stockées pour le changelog, principalement destiné aux calculs sur les projets, ainsi en EPSG:4326.
 
 Il est nécessaire d'avoir une table `pdm_boundary` contenant le découpage administratif de la zone ([niveaux administratifs](https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative) 2, 4, 6 et 8) et ayant cette structure :
 
@@ -704,7 +706,8 @@ La colonne `centre` est comprise comme étant un point compris dans le périmèt
 
 Créer des indexes sur les colonnes `osm_id`, `tags`, `geom` et `centre` peut être utile suivant la population d'objets touchée par un projet donné.
 
-PdM va automatiquement créer une table `pdm_boundary_subdivide` en utilisant [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) pour faciliter le calcul d'intersection entre les objets du projet et le zonage administratif.
+PdM va automatiquement créer une table `pdm_boundary_subdivide` en utilisant [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) pour faciliter le calcul d'intersection entre les objets du projet et le zonage administratif.  
+La seule transformation du système 3857 vers 4326 a lieu lors de la subdivision des périmètres administratifs, pour les comparer aux géométries du changelog pour les calculs localisés sur ces périmètres.
 
 Une fois mise à jour, pensez à propager les changements aux vues utilisants les périmètres administratifs :
 
@@ -720,8 +723,10 @@ osm_id varchar,
 gid bigint,
 name VARCHAR(255)
 tags json
-geom GEOMETRY
+geom GEOMETRY(Geometry, 3857)
 ```
+
+Optionellement, si le mode compare est activé dans un projet donné, une vue supplémentaire appelée `pdm_project_${project_id}_compare` conforme à ce qui doit être comparé est nécessaire. Elle a la même structure que ci-dessus.
 
 #### Remplacé par le journal des modifications
 Dans le cas où vous accepteriez une mise à jour quotidienne de la vue des objets actuels, c'est à dire sans prise en compte immédiate des objets contribués pendant la journée, il est possible de créer manuellement une vue matérialisée comme suit :
@@ -732,7 +737,7 @@ create materialized view pdm_project_projectslug as
   split_part(fc.osmid, '/', 2)::bigint as gid, 
   fc.tags->>'name' as name, 
   to_json(fc.tags) as tags, 
-  ST_Centroid(fc.geom)::geometry(point,4326) as geom 
+  ST_Transform(fc.geom, 3857) as geom,
   from pdm_features_projectslug_changes fc
   where fc.tagsfilter=true and (CURRENT_TIMESTAMP BETWEEN fc.ts_start AND fc.ts_end
         OR (CURRENT_TIMESTAMP > fc.ts_start AND fc.ts_end is null));

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -686,10 +686,14 @@ npm run projects:update
 
 ### Disable imposm3 usage
 
-Is it possible to not use imposm3 and provide an updated database with all necessary data.  
-You must ensure yourself it will be updated at the necessary pace for PdM need, at least daily.
+Is it possible to not use imposm3 and provide a live updated database with all necessary data.  
+You must ensure yourself it will be updated at the necessary pace for PdM need, with minute diffs.
+
+Once setup, don't forget to set `database.live` to `true` in your project(s) configuration.
 
 #### Common principles
+
+All geometries imported by imposm are intended to be displayed in web tiles, so prefer using the EPSG:3857 projection. They differ from the ones stored in the changelog, mainly intended for project computations, thus with EPSG:4326.
 
 A table `pdm_boundary` with every administrative boundaries will be useful to aggregate statistics at several levels. [Administrative boundaries](https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative) 2, 4, 6 and 8 are supported by web interface.  
 It should conform to this structure:
@@ -707,7 +711,8 @@ centre GEOMETRY(Point, 3857)
 `centre` column contains a point that must be inside the boundary perimeter (please use [ST_PointOnSurface](https://postgis.net/docs/ST_PointOnSurface.html) function).  
 Indices should be created on columns `osm_id`, `tags`, `geom` and `centre` depending on the amount of boundaries covering each project.
 
-Processing will automatically derivate another table `pdm_boundary_subdivide` by using [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) as to significantly ease the intersecting computation between features and boundaries.
+Processing will automatically derivate another table `pdm_boundary_subdivide` by using [ST_Subdivide](https://postgis.net/docs/ST_Subdivide.html) as to significantly ease the intersecting computation between features and boundaries.  
+The only transformation from 3857 to 4326 is done on boundaries subdivide, since they are compared to changelog geometries for boundaries counts.
 
 Once updated, use the following to propagate the changes you have made to the boundaries:
 
@@ -723,7 +728,7 @@ osm_id varchar,
 gid bigint,
 name VARCHAR(255)
 tags json
-geom GEOMETRY
+geom GEOMETRY(Geometry, 3857)
 ```
 
 Optionally, if the compare mode is enabled for a given project, a supplemntary view called `pdm_project_${project_id}_compare` that conforms to the given structure for `pdm_project_${project_id}` is needed.
@@ -737,7 +742,7 @@ create materialized view pdm_project_projectslug as
   split_part(fc.osmid, '/', 2)::bigint as gid, 
   fc.tags->>'name' as name, 
   to_json(fc.tags) as tags, 
-  fc.geom 
+  ST_Transform(fc.geom, 3857) as geom,
   from pdm_features_projectslug_changes fc
   where fc.tagsfilter=true and (CURRENT_TIMESTAMP BETWEEN fc.ts_start AND fc.ts_end
         OR (CURRENT_TIMESTAMP > fc.ts_start AND fc.ts_end is null));


### PR DESCRIPTION
After thinking a bit much about this, importing live data in 3857 makes sense as they are mainly intended for web display, in editor and tiles.

So this PR enforces the 3857 for imposm and document a bit much the necessity for the both systems, to avoid as much transformation as possible. They are limited to following situations:
* When using boundaries subdivide, as intended to intersect changelog features geometries (4326) for project computation (3857 => 4326)
* Replacing imposm live data with daily changelog (4326 => 3857)

Hope it's clearer

Fix #399 