### PR TITLE
Fix imposm -srid value

### DIFF
--- a/db/10_features_update.js
+++ b/db/10_features_update.js
@@ -179,7 +179,7 @@ if [ "$mode" == "init" ]; then
 	mkdir -p "${IMPOSM_CACHE_DIR}"
 	imposm import -mapping "${IMPOSM_YML_FS}" \\
 		-read "${OSM_PBF_FS}" \\
-		-srid EPSG:3857 \\
+		-srid 3857 \\
 		-overwritecache -cachedir "${IMPOSM_CACHE_DIR}" \\
 		-diff -diffdir "${IMPOSM_DIFF_DIR}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       context: .
     restart: always
     depends_on:
-      - pgsqldb
+      pgsqldb:
+        condition: service_healthy
+        restart: true
     networks:
       - oim-internal
     ports:
@@ -40,7 +42,9 @@ services:
     image: pramsey/pg_tileserv:latest
     restart: always
     depends_on:
-      - pgsqldb
+      pgsqldb:
+        condition: service_healthy
+        restart: true
     networks:
       - oim-internal
     ports:
@@ -54,7 +58,9 @@ services:
     profiles:
       - pgadmin
     depends_on:
-      - pgsqldb
+      pgsqldb:
+        condition: service_healthy
+        restart: true
     networks:
       - oim-internal
     ports:


### PR DESCRIPTION
After the changes of #431 if I try to run the init script I receive this error:

<img width="592" height="352" alt="image" src="https://github.com/user-attachments/assets/baa446bd-d324-49d9-8ae5-a9ac07b1f5f6" />

I'm using the default version of imposm3, 0.11.0, and the help command says to use only the EPSG number, not the whole string:

```
PS D:\git\podoma> docker compose exec pdm imposm import --help
Usage: imposm import [args]

  -appendcache
        append cache
  -cachedir string
        cache directory (default "/tmp/imposm3")
  -config string
        config (json)
  -connection string
        connection parameters
  -dbschema-backup string
        db schema for backups (default "backup")
  -dbschema-import string
        db schema for imports (default "import")
  -dbschema-production string
        db schema for production (default "public")
  -deployproduction
        deploy production
  -diff
        enable diff support
  -diff-state-before duration
        set initial diff sequence before
  -diffdir string
        diff directory for last.state.txt
  -httpprofile string
        bind address for profile server
  -limitto string
        limit to geometries
  -limittocachebuffer float
        limit to buffer for cache
  -mapping string
        mapping file
  -optimize
        optimize
  -overwritecache
        overwritecache
  -quiet
        quiet log output
  -read string
        read
  -removebackup
        remove backups from deploy
  -replication-interval duration
        replication interval as duration (1m, 1h, 24h) (default 1m0s)
  -revertdeploy
        revert deploy to production
  -srid int
        srs id (default 3857)
  -write
        write
PS D:\git\podoma> docker compose exec pdm imposm version
0.11.0
```

After removing the `EPSG:` part it works fine.

The PR also includes an improvement to the docker compose setup that prevents the services from starting until the DB is ready for usage (not only started)